### PR TITLE
Added season settings, removed group settings

### DIFF
--- a/api/README-Socket-Updates.md
+++ b/api/README-Socket-Updates.md
@@ -113,9 +113,10 @@ A list of all event types with their corresponding dto and all available scopes:
 * **ruleMovesUpdate:** When a rule move is update
 * **ruleMovesDelete:** When a rule move is delete
 
-#### Seasons (body: SeasonDto)
+#### Seasons (body: SeasonStartDto | SeasonDto)
 
 * **seasonStart:** When a new season is started
+* **seasonUpdate:** When a season is updated
 
 #### Assets (body: AssetMetadataDto | ProfileDto)
 

--- a/api/src/main/java/pro/beerpong/api/control/MatchController.java
+++ b/api/src/main/java/pro/beerpong/api/control/MatchController.java
@@ -24,7 +24,7 @@ public class MatchController {
 
     @PostMapping
     public ResponseEntity<ResponseEnvelope<MatchDto>> createMatch(@PathVariable String groupId, @PathVariable String seasonId,
-                                                                  @RequestBody MatchCreateDto matchCreateDt) {
+                                                                  @RequestBody MatchCreateDto matchCreateDto) {
         var pair = seasonService.getSeasonAndGroup(groupId, seasonId);
         var error = seasonService.validateActiveSeason(MatchDto.class, pair);
 
@@ -32,7 +32,11 @@ public class MatchController {
             return error;
         }
 
-        var match = matchService.createNewMatch(pair.getFirst(), pair.getSecond(), matchCreateDt);
+        if (!matchService.validateCreateDto(pair.getSecond(), matchCreateDto)) {
+            return ResponseEnvelope.notOk(HttpStatus.BAD_REQUEST, ErrorCodes.MATCH_CREATE_DTO_VALIDATION_FAILED);
+        }
+
+        var match = matchService.createNewMatch(pair.getFirst(), pair.getSecond(), matchCreateDto);
 
         if (match != null) {
             if (match.getSeason().getId().equals(seasonId) && match.getSeason().getGroupId().equals(groupId)) {
@@ -109,6 +113,10 @@ public class MatchController {
 
         if (error != null || pair.getFirst() == null || pair.getSecond() == null) {
             return error;
+        }
+
+        if (!matchService.validateCreateDto(pair.getSecond(), matchCreateDto)) {
+            return ResponseEnvelope.notOk(HttpStatus.BAD_REQUEST, ErrorCodes.MATCH_CREATE_DTO_VALIDATION_FAILED);
         }
 
         var match = matchService.getRawMatchById(id);

--- a/api/src/main/java/pro/beerpong/api/control/SeasonController.java
+++ b/api/src/main/java/pro/beerpong/api/control/SeasonController.java
@@ -4,10 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import pro.beerpong.api.model.dto.ErrorCodes;
-import pro.beerpong.api.model.dto.ResponseEnvelope;
-import pro.beerpong.api.model.dto.SeasonCreateDto;
-import pro.beerpong.api.model.dto.SeasonDto;
+import pro.beerpong.api.model.dto.*;
 import pro.beerpong.api.service.SeasonService;
 
 import java.util.List;
@@ -44,6 +41,26 @@ public class SeasonController {
 
         if (season != null && season.getGroupId().equals(groupId)) {
             return ResponseEnvelope.ok(season);
+        } else {
+            return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.SEASON_NOT_FOUND);
+        }
+    }
+
+    @PutMapping("/seasons/{id}")
+    public ResponseEntity<ResponseEnvelope<SeasonDto>> updateSeasonById(@PathVariable String groupId, @PathVariable String id, @RequestBody SeasonUpdateDto dto) {
+        var season = seasonService.getRawSeasonById(id);
+
+        if (season.isEmpty()) {
+            return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.SEASON_NOT_FOUND);
+        } else if (!season.get().getGroupId().equals(groupId)) {
+            return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.SEASON_NOT_OF_GROUP);
+        } else if (season.get().getEndDate() != null) {
+            return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.SEASON_ALREADY_ENDED);
+        }
+
+        SeasonDto updatedSeason = seasonService.updateSeason(season.get(), dto);
+        if (updatedSeason != null) {
+            return ResponseEnvelope.ok(updatedSeason);
         } else {
             return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.SEASON_NOT_FOUND);
         }

--- a/api/src/main/java/pro/beerpong/api/model/dao/Group.java
+++ b/api/src/main/java/pro/beerpong/api/model/dao/Group.java
@@ -14,9 +14,6 @@ public class Group {
     private String inviteCode;
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn
-    private GroupSettings groupSettings;
-    @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn
     private Season activeSeason;
     @OneToOne
     @JoinColumn(name = "assetIdWallpaper")

--- a/api/src/main/java/pro/beerpong/api/model/dao/Season.java
+++ b/api/src/main/java/pro/beerpong/api/model/dao/Season.java
@@ -23,12 +23,4 @@ public class Season {
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn
     private SeasonSettings seasonSettings;
-
-    //TODO needed?
-    @PostLoad
-    public void ensureDefaultSeasonSettings() {
-        if (this.seasonSettings == null) {
-            this.seasonSettings = new SeasonSettings();
-        }
-    }
 }

--- a/api/src/main/java/pro/beerpong/api/model/dao/Season.java
+++ b/api/src/main/java/pro/beerpong/api/model/dao/Season.java
@@ -1,9 +1,6 @@
 package pro.beerpong.api.model.dao;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Data;
 
 import java.time.ZonedDateTime;
@@ -22,4 +19,16 @@ public class Season {
     private ZonedDateTime endDate;
 
     private String groupId;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn
+    private SeasonSettings seasonSettings;
+
+    //TODO needed?
+    @PostLoad
+    public void ensureDefaultSeasonSettings() {
+        if (this.seasonSettings == null) {
+            this.seasonSettings = new SeasonSettings();
+        }
+    }
 }

--- a/api/src/main/java/pro/beerpong/api/model/dao/SeasonSettings.java
+++ b/api/src/main/java/pro/beerpong/api/model/dao/SeasonSettings.java
@@ -14,8 +14,8 @@ public class SeasonSettings {
     @GeneratedValue(strategy = GenerationType.UUID)
     private String id;
 
-    private int minMatchesToQualify;
-    private int minTeamSize;
-    private int maxTeamSize;
-    private RankingAlgorithm rankingAlgorithm;
+    private int minMatchesToQualify = 1;
+    private int minTeamSize = 1;
+    private int maxTeamSize = 10;
+    private RankingAlgorithm rankingAlgorithm = RankingAlgorithm.AVERAGE;
 }

--- a/api/src/main/java/pro/beerpong/api/model/dao/SeasonSettings.java
+++ b/api/src/main/java/pro/beerpong/api/model/dao/SeasonSettings.java
@@ -5,13 +5,17 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Data;
+import pro.beerpong.api.util.RankingAlgorithm;
 
-@Entity(name = "group_settings")
+@Entity(name = "season_settings")
 @Data
-public class GroupSettings {
+public class SeasonSettings {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private String id;
 
-    private String settingValue;
+    private int minMatchesToQualify;
+    private int minTeamSize;
+    private int maxTeamSize;
+    private RankingAlgorithm rankingAlgorithm;
 }

--- a/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
@@ -15,6 +15,7 @@ public enum ErrorCodes {
     SEASON_VALIDATION_FAILED("seasonValidationFailed", "The validation of the created season has failed (invalid group id)"),
     MATCH_NOT_FOUND("matchNotFound", "The requested match could not be found!"),
     MATCH_VALIDATION_FAILED("matchValidationFailed", "The validation of the created match has failed (invalid group or season id)"),
+    MATCH_CREATE_DTO_VALIDATION_FAILED("matchCreateDtoValidationFailed", "The team sizes are not in the boundaries of the season settings!"),
     MATCH_DTO_VALIDATION_FAILED("matchDtoValidationFailed", "The validation of the match create dto failed (invalid player, rulemove, season or group id)"),
     RULE_MOVE_NOT_FOUND("ruleMoveNotFound", "The requested ruleMove could not be found!"),
     RULE_MOVE_VALIDATION_FAILED("ruleMoveValidationFailed", "The rulemove is not part of the provided season or the provided season is not part of the provided gorup!"),

--- a/api/src/main/java/pro/beerpong/api/model/dto/GroupDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/GroupDto.java
@@ -2,7 +2,6 @@ package pro.beerpong.api.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
-import pro.beerpong.api.model.dao.GroupSettings;
 import pro.beerpong.api.model.dao.Season;
 
 @Data
@@ -10,7 +9,6 @@ public class GroupDto {
     private String id;
     private String name;
     private String inviteCode;
-    private GroupSettings groupSettings;
     private Season activeSeason;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private AssetMetadataDto wallpaperAsset;

--- a/api/src/main/java/pro/beerpong/api/model/dto/SeasonDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/SeasonDto.java
@@ -1,6 +1,7 @@
 package pro.beerpong.api.model.dto;
 
 import lombok.Data;
+import pro.beerpong.api.model.dao.SeasonSettings;
 
 import java.time.ZonedDateTime;
 
@@ -11,4 +12,5 @@ public class SeasonDto {
     private ZonedDateTime startDate;
     private ZonedDateTime endDate;
     private String groupId;
+    private SeasonSettings seasonSettings;
 }

--- a/api/src/main/java/pro/beerpong/api/model/dto/SeasonUpdateDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/SeasonUpdateDto.java
@@ -1,0 +1,12 @@
+package pro.beerpong.api.model.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import pro.beerpong.api.model.dao.SeasonSettings;
+
+import java.util.List;
+
+@Data
+public class SeasonUpdateDto {
+    private @NotNull SeasonSettings seasonSettings;
+}

--- a/api/src/main/java/pro/beerpong/api/service/GroupService.java
+++ b/api/src/main/java/pro/beerpong/api/service/GroupService.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import pro.beerpong.api.mapping.GroupMapper;
 import pro.beerpong.api.model.dao.Group;
-import pro.beerpong.api.model.dao.GroupSettings;
 import pro.beerpong.api.model.dao.Season;
 import pro.beerpong.api.model.dto.AssetMetadataDto;
 import pro.beerpong.api.model.dto.GroupCreateDto;
@@ -40,7 +39,6 @@ public class GroupService {
     public GroupDto createGroup(GroupCreateDto groupCreateDto) {
         Group group = groupMapper.groupCreateDtoToGroup(groupCreateDto);
         group.setInviteCode(generateRandomString(9));
-        group.setGroupSettings(new GroupSettings());
 
         var season = new Season();
         season.setStartDate(ZonedDateTime.now());

--- a/api/src/main/java/pro/beerpong/api/service/MatchService.java
+++ b/api/src/main/java/pro/beerpong/api/service/MatchService.java
@@ -15,6 +15,7 @@ import pro.beerpong.api.sockets.SubscriptionHandler;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 @Service
@@ -210,6 +211,14 @@ public class MatchService {
         ));
 
         return dto;
+    }
+
+    public boolean validateCreateDto(Season season, MatchCreateDto dto) {
+        var settings = Optional.ofNullable(season.getSeasonSettings()).orElse(new SeasonSettings());
+
+        return dto.getTeams().stream().allMatch(teamCreateDto ->
+                teamCreateDto.getTeamMembers().size() >= settings.getMinTeamSize() &&
+                        teamCreateDto.getTeamMembers().size() <= settings.getMaxTeamSize());
     }
 
     public Match getRawMatchById(String id) {

--- a/api/src/main/java/pro/beerpong/api/service/SeasonService.java
+++ b/api/src/main/java/pro/beerpong/api/service/SeasonService.java
@@ -59,7 +59,15 @@ public class SeasonService {
 
         season.setStartDate(ZonedDateTime.now());
         season.setGroupId(groupOptional.get().getId());
-        season.setSeasonSettings((oldSeason != null && oldSeason.getSeasonSettings() != null ? oldSeason.getSeasonSettings() : new SeasonSettings()));
+        season.setSeasonSettings(new SeasonSettings());
+
+        if (oldSeason != null && oldSeason.getSeasonSettings() != null) {
+            season.getSeasonSettings().setMaxTeamSize(oldSeason.getSeasonSettings().getMaxTeamSize());
+            season.getSeasonSettings().setMinTeamSize(oldSeason.getSeasonSettings().getMinTeamSize());
+            season.getSeasonSettings().setMinMatchesToQualify(oldSeason.getSeasonSettings().getMinMatchesToQualify());
+            season.getSeasonSettings().setRankingAlgorithm(oldSeason.getSeasonSettings().getRankingAlgorithm());
+        }
+
         season = seasonRepository.save(season);
 
         if (oldSeason != null) {

--- a/api/src/main/java/pro/beerpong/api/service/SeasonService.java
+++ b/api/src/main/java/pro/beerpong/api/service/SeasonService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import pro.beerpong.api.mapping.SeasonMapper;
 import pro.beerpong.api.model.dao.Group;
 import pro.beerpong.api.model.dao.Season;
+import pro.beerpong.api.model.dao.SeasonSettings;
 import pro.beerpong.api.model.dto.*;
 import pro.beerpong.api.repository.GroupRepository;
 import pro.beerpong.api.repository.SeasonRepository;
@@ -54,12 +55,12 @@ public class SeasonService {
 
         var group = groupOptional.get();
         var season = new Season();
+        var oldSeason = group.getActiveSeason();
 
         season.setStartDate(ZonedDateTime.now());
         season.setGroupId(groupOptional.get().getId());
+        season.setSeasonSettings((oldSeason != null && oldSeason.getSeasonSettings() != null ? oldSeason.getSeasonSettings() : new SeasonSettings()));
         season = seasonRepository.save(season);
-
-        var oldSeason = group.getActiveSeason();
 
         if (oldSeason != null) {
             oldSeason.setName(dto.getOldSeasonName());

--- a/api/src/main/java/pro/beerpong/api/sockets/SocketEventData.java
+++ b/api/src/main/java/pro/beerpong/api/sockets/SocketEventData.java
@@ -25,6 +25,7 @@ public class SocketEventData<T> {
     public static final SocketEventData<RuleMoveDto> RULE_MOVE_DELETE = new SocketEventData<>(RuleMoveDto.class, SocketEventType.RULE_MOVES, "ruleMovesDelete");
 
     public static final SocketEventData<SeasonStartDto> SEASON_START = new SocketEventData<>(SeasonStartDto.class, SocketEventType.SEASONS, "seasonStart");
+    public static final SocketEventData<SeasonDto> SEASON_UPDATE = new SocketEventData<>(SeasonDto.class, SocketEventType.SEASONS, "seasonUpdate");
 
     public static final SocketEventData<ProfileDto> PROFILE_AVATAR_SET = new SocketEventData<>(ProfileDto.class, SocketEventType.ASSETS, "profileAvatarSet");
     public static final SocketEventData<AssetMetadataDto> GROUP_WALLPAPER_SET = new SocketEventData<>(AssetMetadataDto.class, SocketEventType.ASSETS, "groupWallpaperSet");

--- a/api/src/main/java/pro/beerpong/api/util/RankingAlgorithm.java
+++ b/api/src/main/java/pro/beerpong/api/util/RankingAlgorithm.java
@@ -1,0 +1,10 @@
+package pro.beerpong.api.util;
+
+public enum RankingAlgorithm {
+    AVERAGE,
+    ELO;
+
+    public String getId() {
+        return this.name().toLowerCase();
+    }
+}

--- a/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
+++ b/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
@@ -71,8 +71,8 @@ public class CreateMatchTest {
         assertEquals(prerequisiteGroup, group);
         assertNotNull(group.getId());
         assertNotNull(group.getInviteCode());
-        assertNotNull(group.getGroupSettings());
-        assertNotNull(group.getGroupSettings().getId());
+        assertNotNull(group.getSeasonSettings());
+        assertNotNull(group.getSeasonSettings().getId());
         assertNotNull(group.getActiveSeason());
         assertNotNull(group.getActiveSeason().getId());
         assertEquals(group.getActiveSeason().getGroupId(), group.getId());

--- a/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
+++ b/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
@@ -71,8 +71,6 @@ public class CreateMatchTest {
         assertEquals(prerequisiteGroup, group);
         assertNotNull(group.getId());
         assertNotNull(group.getInviteCode());
-        assertNotNull(group.getSeasonSettings());
-        assertNotNull(group.getSeasonSettings().getId());
         assertNotNull(group.getActiveSeason());
         assertNotNull(group.getActiveSeason().getId());
         assertEquals(group.getActiveSeason().getGroupId(), group.getId());

--- a/api/src/test/java/pro/beerpong/api/control/GroupControllerTest.java
+++ b/api/src/test/java/pro/beerpong/api/control/GroupControllerTest.java
@@ -50,8 +50,6 @@ public class GroupControllerTest {
         assertEquals(createDto.getName(), group.getName());
         assertNotNull(group.getId());
         assertNotNull(group.getInviteCode());
-        assertNotNull(group.getSeasonSettings());
-        assertNotNull(group.getSeasonSettings().getId());
         assertNotNull(group.getActiveSeason());
         assertNotNull(group.getActiveSeason().getId());
         assertEquals(group.getActiveSeason().getGroupId(), group.getId());
@@ -99,8 +97,6 @@ public class GroupControllerTest {
         assertEquals(prerequisiteGroup, group);
         assertNotNull(group.getId());
         assertNotNull(group.getInviteCode());
-        assertNotNull(group.getSeasonSettings());
-        assertNotNull(group.getSeasonSettings().getId());
         assertNotNull(group.getActiveSeason());
         assertNotNull(group.getActiveSeason().getId());
         assertEquals(group.getActiveSeason().getGroupId(), group.getId());

--- a/api/src/test/java/pro/beerpong/api/control/GroupControllerTest.java
+++ b/api/src/test/java/pro/beerpong/api/control/GroupControllerTest.java
@@ -50,8 +50,8 @@ public class GroupControllerTest {
         assertEquals(createDto.getName(), group.getName());
         assertNotNull(group.getId());
         assertNotNull(group.getInviteCode());
-        assertNotNull(group.getGroupSettings());
-        assertNotNull(group.getGroupSettings().getId());
+        assertNotNull(group.getSeasonSettings());
+        assertNotNull(group.getSeasonSettings().getId());
         assertNotNull(group.getActiveSeason());
         assertNotNull(group.getActiveSeason().getId());
         assertEquals(group.getActiveSeason().getGroupId(), group.getId());
@@ -99,8 +99,8 @@ public class GroupControllerTest {
         assertEquals(prerequisiteGroup, group);
         assertNotNull(group.getId());
         assertNotNull(group.getInviteCode());
-        assertNotNull(group.getGroupSettings());
-        assertNotNull(group.getGroupSettings().getId());
+        assertNotNull(group.getSeasonSettings());
+        assertNotNull(group.getSeasonSettings().getId());
         assertNotNull(group.getActiveSeason());
         assertNotNull(group.getActiveSeason().getId());
         assertEquals(group.getActiveSeason().getGroupId(), group.getId());

--- a/mobile-app/api/generated/openapi.json
+++ b/mobile-app/api/generated/openapi.json
@@ -345,6 +345,78 @@
                 }
             }
         },
+        "/groups/{groupId}/seasons/{id}": {
+            "get": {
+                "tags": ["season-controller"],
+                "operationId": "getSeasonById",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    },
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseEnvelopeSeasonDto"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": ["season-controller"],
+                "operationId": "updateSeasonById",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    },
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SeasonUpdateDto"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseEnvelopeSeasonDto"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/groups/{groupId}/profiles/{profileId}/avatar": {
             "put": {
                 "tags": ["profile-asset-controller"],
@@ -895,38 +967,6 @@
                 }
             }
         },
-        "/groups/{groupId}/seasons/{id}": {
-            "get": {
-                "tags": ["season-controller"],
-                "operationId": "getSeasonById",
-                "parameters": [
-                    {
-                        "name": "groupId",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string" }
-                    },
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string" }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ResponseEnvelopeSeasonDto"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/assets/{id}": {
             "get": {
                 "tags": ["asset-controller"],
@@ -1050,9 +1090,6 @@
                     "id": { "type": "string" },
                     "name": { "type": "string" },
                     "inviteCode": { "type": "string" },
-                    "groupSettings": {
-                        "$ref": "#/components/schemas/GroupSettings"
-                    },
                     "activeSeason": { "$ref": "#/components/schemas/Season" },
                     "wallpaperAsset": {
                         "$ref": "#/components/schemas/AssetMetadataDto"
@@ -1060,13 +1097,6 @@
                     "numberOfPlayers": { "type": "integer", "format": "int32" },
                     "numberOfMatches": { "type": "integer", "format": "int32" },
                     "numberOfSeasons": { "type": "integer", "format": "int32" }
-                }
-            },
-            "GroupSettings": {
-                "type": "object",
-                "properties": {
-                    "id": { "type": "string" },
-                    "settingValue": { "type": "string" }
                 }
             },
             "ResponseEnvelopeGroupDto": {
@@ -1085,7 +1115,26 @@
                     "name": { "type": "string" },
                     "startDate": { "type": "string", "format": "date-time" },
                     "endDate": { "type": "string", "format": "date-time" },
-                    "groupId": { "type": "string" }
+                    "groupId": { "type": "string" },
+                    "seasonSettings": {
+                        "$ref": "#/components/schemas/SeasonSettings"
+                    }
+                }
+            },
+            "SeasonSettings": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "minMatchesToQualify": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "minTeamSize": { "type": "integer", "format": "int32" },
+                    "maxTeamSize": { "type": "integer", "format": "int32" },
+                    "rankingAlgorithm": {
+                        "type": "string",
+                        "enum": ["AVERAGE", "ELO"]
+                    }
                 }
             },
             "ResponseEnvelopeAssetMetadataDto": {
@@ -1250,6 +1299,37 @@
                     "playerId": { "type": "string" }
                 }
             },
+            "SeasonUpdateDto": {
+                "required": ["seasonSettings"],
+                "type": "object",
+                "properties": {
+                    "seasonSettings": {
+                        "$ref": "#/components/schemas/SeasonSettings"
+                    }
+                }
+            },
+            "ResponseEnvelopeSeasonDto": {
+                "type": "object",
+                "properties": {
+                    "status": { "type": "string", "enum": ["OK", "ERROR"] },
+                    "httpCode": { "type": "integer", "format": "int32" },
+                    "data": { "$ref": "#/components/schemas/SeasonDto" },
+                    "error": { "$ref": "#/components/schemas/ErrorDetails" }
+                }
+            },
+            "SeasonDto": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "name": { "type": "string" },
+                    "startDate": { "type": "string", "format": "date-time" },
+                    "endDate": { "type": "string", "format": "date-time" },
+                    "groupId": { "type": "string" },
+                    "seasonSettings": {
+                        "$ref": "#/components/schemas/SeasonSettings"
+                    }
+                }
+            },
             "ProfileDto": {
                 "type": "object",
                 "properties": {
@@ -1277,25 +1357,6 @@
             "SeasonCreateDto": {
                 "type": "object",
                 "properties": { "oldSeasonName": { "type": "string" } }
-            },
-            "ResponseEnvelopeSeasonDto": {
-                "type": "object",
-                "properties": {
-                    "status": { "type": "string", "enum": ["OK", "ERROR"] },
-                    "httpCode": { "type": "integer", "format": "int32" },
-                    "data": { "$ref": "#/components/schemas/SeasonDto" },
-                    "error": { "$ref": "#/components/schemas/ErrorDetails" }
-                }
-            },
-            "SeasonDto": {
-                "type": "object",
-                "properties": {
-                    "id": { "type": "string" },
-                    "name": { "type": "string" },
-                    "startDate": { "type": "string", "format": "date-time" },
-                    "endDate": { "type": "string", "format": "date-time" },
-                    "groupId": { "type": "string" }
-                }
             },
             "ResponseEnvelopeString": {
                 "type": "object",

--- a/mobile-app/openapi/openapi.d.ts
+++ b/mobile-app/openapi/openapi.d.ts
@@ -26,16 +26,11 @@ declare namespace Components {
             id?: string;
             name?: string;
             inviteCode?: string;
-            groupSettings?: GroupSettings;
             activeSeason?: Season;
             wallpaperAsset?: AssetMetadataDto;
             numberOfPlayers?: number; // int32
             numberOfMatches?: number; // int32
             numberOfSeasons?: number; // int32
-        }
-        export interface GroupSettings {
-            id?: string;
-            settingValue?: string;
         }
         export interface MatchCreateDto {
             teams?: TeamCreateDto[];
@@ -213,6 +208,7 @@ declare namespace Components {
             startDate?: string; // date-time
             endDate?: string; // date-time
             groupId?: string;
+            seasonSettings?: SeasonSettings;
         }
         export interface SeasonCreateDto {
             oldSeasonName?: string;
@@ -223,6 +219,17 @@ declare namespace Components {
             startDate?: string; // date-time
             endDate?: string; // date-time
             groupId?: string;
+            seasonSettings?: SeasonSettings;
+        }
+        export interface SeasonSettings {
+            id?: string;
+            minMatchesToQualify?: number; // int32
+            minTeamSize?: number; // int32
+            maxTeamSize?: number; // int32
+            rankingAlgorithm?: 'AVERAGE' | 'ELO';
+        }
+        export interface SeasonUpdateDto {
+            seasonSettings: SeasonSettings;
         }
         export interface TeamCreateDto {
             teamMembers?: TeamMemberCreateDto[];
@@ -613,6 +620,20 @@ declare namespace Paths {
             export type $200 = Components.Schemas.ResponseEnvelopeRuleMoveDto;
         }
     }
+    namespace UpdateSeasonById {
+        namespace Parameters {
+            export type GroupId = string;
+            export type Id = string;
+        }
+        export interface PathParameters {
+            groupId: Parameters.GroupId;
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.SeasonUpdateDto;
+        namespace Responses {
+            export type $200 = Components.Schemas.ResponseEnvelopeSeasonDto;
+        }
+    }
     namespace WriteRules {
         namespace Parameters {
             export type GroupId = string;
@@ -702,6 +723,22 @@ export interface OperationMethods {
         data?: Paths.UpdateMatch.RequestBody,
         config?: AxiosRequestConfig
     ): OperationResponse<Paths.UpdateMatch.Responses.$200>;
+    /**
+     * getSeasonById
+     */
+    'getSeasonById'(
+        parameters?: Parameters<Paths.GetSeasonById.PathParameters> | null,
+        data?: any,
+        config?: AxiosRequestConfig
+    ): OperationResponse<Paths.GetSeasonById.Responses.$200>;
+    /**
+     * updateSeasonById
+     */
+    'updateSeasonById'(
+        parameters?: Parameters<Paths.UpdateSeasonById.PathParameters> | null,
+        data?: Paths.UpdateSeasonById.RequestBody,
+        config?: AxiosRequestConfig
+    ): OperationResponse<Paths.UpdateSeasonById.Responses.$200>;
     /**
      * setAvatar
      */
@@ -839,14 +876,6 @@ export interface OperationMethods {
         config?: AxiosRequestConfig
     ): OperationResponse<Paths.GetAllMatchOverviews.Responses.$200>;
     /**
-     * getSeasonById
-     */
-    'getSeasonById'(
-        parameters?: Parameters<Paths.GetSeasonById.PathParameters> | null,
-        data?: any,
-        config?: AxiosRequestConfig
-    ): OperationResponse<Paths.GetSeasonById.Responses.$200>;
-    /**
      * getAsset
      */
     'getAsset'(
@@ -954,6 +983,24 @@ export interface PathsDictionary {
             data?: Paths.UpdateMatch.RequestBody,
             config?: AxiosRequestConfig
         ): OperationResponse<Paths.UpdateMatch.Responses.$200>;
+    };
+    ['/groups/{groupId}/seasons/{id}']: {
+        /**
+         * getSeasonById
+         */
+        'get'(
+            parameters?: Parameters<Paths.GetSeasonById.PathParameters> | null,
+            data?: any,
+            config?: AxiosRequestConfig
+        ): OperationResponse<Paths.GetSeasonById.Responses.$200>;
+        /**
+         * updateSeasonById
+         */
+        'put'(
+            parameters?: Parameters<Paths.UpdateSeasonById.PathParameters> | null,
+            data?: Paths.UpdateSeasonById.RequestBody,
+            config?: AxiosRequestConfig
+        ): OperationResponse<Paths.UpdateSeasonById.Responses.$200>;
     };
     ['/groups/{groupId}/profiles/{profileId}/avatar']: {
         /**
@@ -1115,16 +1162,6 @@ export interface PathsDictionary {
             config?: AxiosRequestConfig
         ): OperationResponse<Paths.GetAllMatchOverviews.Responses.$200>;
     };
-    ['/groups/{groupId}/seasons/{id}']: {
-        /**
-         * getSeasonById
-         */
-        'get'(
-            parameters?: Parameters<Paths.GetSeasonById.PathParameters> | null,
-            data?: any,
-            config?: AxiosRequestConfig
-        ): OperationResponse<Paths.GetSeasonById.Responses.$200>;
-    };
     ['/assets/{id}']: {
         /**
          * getAsset
@@ -1163,7 +1200,6 @@ export type AssetMetadataDto = Components.Schemas.AssetMetadataDto;
 export type ErrorDetails = Components.Schemas.ErrorDetails;
 export type GroupCreateDto = Components.Schemas.GroupCreateDto;
 export type GroupDto = Components.Schemas.GroupDto;
-export type GroupSettings = Components.Schemas.GroupSettings;
 export type MatchCreateDto = Components.Schemas.MatchCreateDto;
 export type MatchDto = Components.Schemas.MatchDto;
 export type MatchMoveDto = Components.Schemas.MatchMoveDto;
@@ -1212,6 +1248,8 @@ export type RuleMoveDto = Components.Schemas.RuleMoveDto;
 export type Season = Components.Schemas.Season;
 export type SeasonCreateDto = Components.Schemas.SeasonCreateDto;
 export type SeasonDto = Components.Schemas.SeasonDto;
+export type SeasonSettings = Components.Schemas.SeasonSettings;
+export type SeasonUpdateDto = Components.Schemas.SeasonUpdateDto;
 export type TeamCreateDto = Components.Schemas.TeamCreateDto;
 export type TeamDto = Components.Schemas.TeamDto;
 export type TeamMemberCreateDto = Components.Schemas.TeamMemberCreateDto;


### PR DESCRIPTION
- New season settings entity attached to every season
- Settings are copied from the old season
- Removed group settings
- Enforcing team size bounaries on match create/update
- Added new season update endpoint:
```
PUT /group/:groupId/season/:seasonid
{
   "seasonSettings": {
        "minTeamSize": 1, // min team size
        "maxTeamSize": 1, // max team size
        "minMatchesToQualify": 1, // matches needed to be counted on the leaderboard
        "rankingAlgorithm": "AVERAGE" // AVERAGE | ELO
    }
}
```
- Added seaon update event

closes #98 