### PR TITLE
Leaderboard controller

### DIFF
--- a/api/src/main/java/pro/beerpong/api/control/LeaderboardController.java
+++ b/api/src/main/java/pro/beerpong/api/control/LeaderboardController.java
@@ -1,0 +1,41 @@
+package pro.beerpong.api.control;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.annotation.*;
+import pro.beerpong.api.model.dto.*;
+import pro.beerpong.api.service.GroupService;
+import pro.beerpong.api.service.LeaderboardService;
+import pro.beerpong.api.service.SeasonService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/groups/{groupId}")
+public class LeaderboardController {
+    private final LeaderboardService leaderboardService;
+    private final GroupService groupService;
+
+    @Autowired
+    public LeaderboardController(LeaderboardService leaderboardService, GroupService groupService) {
+        this.leaderboardService = leaderboardService;
+        this.groupService = groupService;
+    }
+
+    @GetMapping("/leaderboard")
+    public ResponseEntity<ResponseEnvelope<LeaderboardDto>> getLeaderboard(@PathVariable String groupId, @RequestParam String scope, @RequestParam(required = false) @Nullable String seasonId) {
+        var group = groupService.getGroupById(groupId);
+
+        if (group == null) {
+            return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.GROUP_NOT_FOUND);
+        } else if (!scope.equals("season") && !scope.equals("today") && !scope.equals("all-time")) {
+            return ResponseEnvelope.notOk(HttpStatus.BAD_REQUEST, ErrorCodes.LEADERBOARD_SCOPE_NOT_FOUND);
+        } else if (scope.equals("season") && seasonId == null) {
+            return ResponseEnvelope.notOk(HttpStatus.BAD_REQUEST, ErrorCodes.LEADERBOARD_SEASON_NOT_FOUND);
+        }
+
+        //TODO
+    }
+}

--- a/api/src/main/java/pro/beerpong/api/control/LeaderboardController.java
+++ b/api/src/main/java/pro/beerpong/api/control/LeaderboardController.java
@@ -39,9 +39,9 @@ public class LeaderboardController {
             return ResponseEnvelope.notOk(HttpStatus.BAD_REQUEST, ErrorCodes.LEADERBOARD_SEASON_NOT_FOUND);
         } else if (scope.equals("season") && !seasonRepository.existsById(seasonId)) {
             return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.SEASON_NOT_FOUND);
+        } else if (scope.equals("season") && !seasonRepository.findById(seasonId).orElseThrow().getGroupId().equals(groupId)) {
+            return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.SEASON_NOT_OF_GROUP);
         }
-
-        //TODO add check if season is of group
 
         var leaderboard = leaderboardService.generateLeaderboard(group, scope, seasonId);
 

--- a/api/src/main/java/pro/beerpong/api/control/LeaderboardController.java
+++ b/api/src/main/java/pro/beerpong/api/control/LeaderboardController.java
@@ -36,6 +36,12 @@ public class LeaderboardController {
             return ResponseEnvelope.notOk(HttpStatus.BAD_REQUEST, ErrorCodes.LEADERBOARD_SEASON_NOT_FOUND);
         }
 
-        //TODO
+        var leaderboard = leaderboardService.generateLeaderboard(group, scope, seasonId);
+
+        if (leaderboard == null) {
+            return ResponseEnvelope.notOk(HttpStatus.BAD_REQUEST, ErrorCodes.LEADERBOARD_SEASON_NOT_FOUND);
+        }
+
+        return ResponseEnvelope.ok(leaderboard);
     }
 }

--- a/api/src/main/java/pro/beerpong/api/control/MatchController.java
+++ b/api/src/main/java/pro/beerpong/api/control/MatchController.java
@@ -59,7 +59,7 @@ public class MatchController {
             return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.SEASON_NOT_OF_GROUP);
         }
 
-        return ResponseEnvelope.ok(matchService.getAllMatches(seasonId));
+        return ResponseEnvelope.ok(matchService.streamAllMatchesInSeason(seasonId).toList());
     }
 
     @GetMapping("/{id}")

--- a/api/src/main/java/pro/beerpong/api/control/MatchController.java
+++ b/api/src/main/java/pro/beerpong/api/control/MatchController.java
@@ -70,7 +70,7 @@ public class MatchController {
             if (match.getSeason().getId().equals(seasonId) && match.getSeason().getGroupId().equals(groupId)) {
                 return ResponseEnvelope.ok(match);
             } else {
-                return ResponseEnvelope.notOk(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCodes.SEASON_NOT_OF_GROUP);
+                return ResponseEnvelope.notOk(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCodes.MATCH_DTO_VALIDATION_FAILED);
             }
         } else {
             return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.MATCH_NOT_FOUND);

--- a/api/src/main/java/pro/beerpong/api/control/MatchController.java
+++ b/api/src/main/java/pro/beerpong/api/control/MatchController.java
@@ -32,7 +32,7 @@ public class MatchController {
             return error;
         }
 
-        if (!matchService.validateCreateDto(pair.getSecond(), matchCreateDto)) {
+        if (matchService.hasWrongTeamSizes(pair.getSecond(), matchCreateDto)) {
             return ResponseEnvelope.notOk(HttpStatus.BAD_REQUEST, ErrorCodes.MATCH_CREATE_DTO_VALIDATION_FAILED);
         }
 
@@ -115,7 +115,7 @@ public class MatchController {
             return error;
         }
 
-        if (!matchService.validateCreateDto(pair.getSecond(), matchCreateDto)) {
+        if (matchService.hasWrongTeamSizes(pair.getSecond(), matchCreateDto)) {
             return ResponseEnvelope.notOk(HttpStatus.BAD_REQUEST, ErrorCodes.MATCH_CREATE_DTO_VALIDATION_FAILED);
         }
 
@@ -125,6 +125,8 @@ public class MatchController {
             return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.MATCH_NOT_FOUND);
         } else if (!match.getSeason().getId().equals(seasonId) || !match.getSeason().getGroupId().equals(groupId)) {
             return ResponseEnvelope.notOk(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCodes.SEASON_NOT_OF_GROUP);
+        } else if (matchService.invalidCreateDto(pair.getFirst().getId(), pair.getSecond().getId(), matchCreateDto)) {
+            return ResponseEnvelope.notOk(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCodes.MATCH_DTO_VALIDATION_FAILED);
         }
 
         return ResponseEnvelope.ok(matchService.updateMatch(pair.getFirst(), match, matchCreateDto));

--- a/api/src/main/java/pro/beerpong/api/control/SeasonController.java
+++ b/api/src/main/java/pro/beerpong/api/control/SeasonController.java
@@ -66,7 +66,7 @@ public class SeasonController {
 
         dto.getSeasonSettings().setMinMatchesToQualify(Math.min(Math.max(dto.getSeasonSettings().getMinMatchesToQualify(), 0), 1000));
         dto.getSeasonSettings().setMinTeamSize(Math.min(Math.max(dto.getSeasonSettings().getMinTeamSize(), 1), 10));
-        dto.getSeasonSettings().setMaxTeamSize(Math.min(Math.max(dto.getSeasonSettings().getMinMatchesToQualify(), 1), 10));
+        dto.getSeasonSettings().setMaxTeamSize(Math.min(Math.max(dto.getSeasonSettings().getMaxTeamSize(), 1), 10));
 
         SeasonDto updatedSeason = seasonService.updateSeason(season.get(), dto);
         if (updatedSeason != null) {

--- a/api/src/main/java/pro/beerpong/api/control/SeasonController.java
+++ b/api/src/main/java/pro/beerpong/api/control/SeasonController.java
@@ -58,6 +58,16 @@ public class SeasonController {
             return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.SEASON_ALREADY_ENDED);
         }
 
+        if (dto.getSeasonSettings().getWakeTimeHour() < 0 || dto.getSeasonSettings().getWakeTimeHour() > 23) {
+            return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.SEASON_WRONG_TIME_FORMAT);
+        } else if (dto.getSeasonSettings().getMinTeamSize() > dto.getSeasonSettings().getMaxTeamSize()) {
+            return ResponseEnvelope.notOk(HttpStatus.NOT_FOUND, ErrorCodes.SEASON_WRONG_TEAM_SIZES);
+        }
+
+        dto.getSeasonSettings().setMinMatchesToQualify(Math.min(Math.max(dto.getSeasonSettings().getMinMatchesToQualify(), 0), 1000));
+        dto.getSeasonSettings().setMinTeamSize(Math.min(Math.max(dto.getSeasonSettings().getMinTeamSize(), 1), 10));
+        dto.getSeasonSettings().setMaxTeamSize(Math.min(Math.max(dto.getSeasonSettings().getMinMatchesToQualify(), 1), 10));
+
         SeasonDto updatedSeason = seasonService.updateSeason(season.get(), dto);
         if (updatedSeason != null) {
             return ResponseEnvelope.ok(updatedSeason);

--- a/api/src/main/java/pro/beerpong/api/model/dao/SeasonSettings.java
+++ b/api/src/main/java/pro/beerpong/api/model/dao/SeasonSettings.java
@@ -5,6 +5,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Data;
+import pro.beerpong.api.util.DailyLeaderboard;
 import pro.beerpong.api.util.RankingAlgorithm;
 
 @Entity(name = "season_settings")
@@ -18,4 +19,5 @@ public class SeasonSettings {
     private int minTeamSize = 1;
     private int maxTeamSize = 10;
     private RankingAlgorithm rankingAlgorithm = RankingAlgorithm.AVERAGE;
+    private DailyLeaderboard dailyLeaderboard = DailyLeaderboard.RESET_AT_MIDNIGHT;
 }

--- a/api/src/main/java/pro/beerpong/api/model/dao/SeasonSettings.java
+++ b/api/src/main/java/pro/beerpong/api/model/dao/SeasonSettings.java
@@ -20,4 +20,5 @@ public class SeasonSettings {
     private int maxTeamSize = 10;
     private RankingAlgorithm rankingAlgorithm = RankingAlgorithm.AVERAGE;
     private DailyLeaderboard dailyLeaderboard = DailyLeaderboard.RESET_AT_MIDNIGHT;
+    private int wakeTimeHour = 7;
 }

--- a/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
@@ -11,6 +11,8 @@ public enum ErrorCodes {
     GROUP_INVITE_CODE_NOT_PROVIDED("groupInviteCodeNotProvided", "The invite code needs to be provided!"),
     SEASON_NOT_FOUND("seasonNotFound", "The requested season could not be found!"),
     SEASON_ALREADY_ENDED("seasonAlreadyEnded", "Past seasons are immutable!"),
+    SEASON_WRONG_TIME_FORMAT("seasonWrongTimeFormat", "The wake time hour has to be between 0 and 23!"),
+    SEASON_WRONG_TEAM_SIZES("seasonWrongTeamSizes", "The min team size has to be less then or equal to the max team size!"),
     SEASON_NOT_OF_GROUP("seasonHasDifferentGroup", "The season does not match the provided group id!"),
     SEASON_VALIDATION_FAILED("seasonValidationFailed", "The validation of the created season has failed (invalid group id)"),
     MATCH_NOT_FOUND("matchNotFound", "The requested match could not be found!"),

--- a/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
@@ -16,7 +16,7 @@ public enum ErrorCodes {
     MATCH_NOT_FOUND("matchNotFound", "The requested match could not be found!"),
     MATCH_VALIDATION_FAILED("matchValidationFailed", "The validation of the created match has failed (invalid group or season id)"),
     MATCH_CREATE_DTO_VALIDATION_FAILED("matchCreateDtoValidationFailed", "The team sizes are not in the boundaries of the season settings!"),
-    MATCH_DTO_VALIDATION_FAILED("matchDtoValidationFailed", "The validation of the match create dto failed (invalid player, rulemove, season or group id)"),
+    MATCH_DTO_VALIDATION_FAILED("matchDtoValidationFailed", "The validation of the match create dto failed (invalid player, rulemove, season or group id, or no finish move)"),
     RULE_MOVE_NOT_FOUND("ruleMoveNotFound", "The requested ruleMove could not be found!"),
     RULE_MOVE_VALIDATION_FAILED("ruleMoveValidationFailed", "The rulemove is not part of the provided season or the provided season is not part of the provided gorup!"),
     RULE_VALIDATION_FAILED("ruleValidationFailed", "The validation of the created rules has failed (invalid group or season id)"),

--- a/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
@@ -23,7 +23,9 @@ public enum ErrorCodes {
     PLAYER_VALIDATION_FAILED("playerValidationFailed", "The player is not part of the provided season or group!"),
     PLAYER_NOT_FOUND("playerNotFound", "The requested player could not be found!"),
     PROFILE_NOT_FOUND("profileNotFound", "The requested profile could not be found!"),
-    ASSET_NOT_FOUND("assetNotFound", "The requested asset could not be found!");
+    ASSET_NOT_FOUND("assetNotFound", "The requested asset could not be found!"),
+    LEADERBOARD_SCOPE_NOT_FOUND("leaderboardScopeNotFound", "The leaderboard scope has to be one of: all-time, today, season"),
+    LEADERBOARD_SEASON_NOT_FOUND("leaderboardScopeNotFound", "The scope 'season' requires a seasonId param!");
 
     private final String code;
     private final String description;

--- a/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardDto.java
@@ -1,0 +1,10 @@
+package pro.beerpong.api.model.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class LeaderboardDto {
+    private List<LeaderboardEntryDto> entries;
+}

--- a/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
@@ -17,7 +17,7 @@ public class LeaderboardEntryDto {
     private double averagePointsPerMatch = 0.0D;
     private double averageEloPerMatch = 0.0D;
     private double averageTeamSize = 0.0D;
-    private double elo = 0;
+    private double elo = 100D;
     private Map<RankingAlgorithm, Integer> rankBy = Maps.newHashMap();
 
     public void addTotalPoints(int amount) {
@@ -41,7 +41,7 @@ public class LeaderboardEntryDto {
     }
 
     public void addElo(double normalizedElo) {
-        this.elo += normalizedElo;
+        this.elo = Math.max(this.elo + normalizedElo, 0D);
     }
 
     public void calculate() {

--- a/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
@@ -35,7 +35,7 @@ public class LeaderboardEntryDto {
     }
 
     public void calculate() {
-        this.averagePointsPerMatch = (double) totalPoints / (double) totalGames;
-        this.averageTeamSize = (double) totalTeamSize / (double) totalGames;
+        this.averagePointsPerMatch = totalGames > 0 ? (double) totalPoints / (double) totalGames : 0;
+        this.averageTeamSize = totalGames > 0 ? (double) totalTeamSize / (double) totalGames : 0;
     }
 }

--- a/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
@@ -11,6 +11,7 @@ public class LeaderboardEntryDto {
     private String playerId;
     private int totalPoints = 0;
     private int totalGames = 0;
+    private int totalGamePoints = 0;
     private int totalMoves = 0;
     private int totalTeamSize = 0;
     private double averagePointsPerMatch = 0.0D;
@@ -24,6 +25,10 @@ public class LeaderboardEntryDto {
 
     public void addTotalGames() {
         this.totalGames++;
+    }
+
+    public void addTotalGamePoints(int amount) {
+        this.totalGamePoints += amount;
     }
 
     public void addTotalMoves(int amount) {

--- a/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
@@ -11,11 +11,9 @@ public class LeaderboardEntryDto {
     private String playerId;
     private int totalPoints = 0;
     private int totalGames = 0;
-    private int totalGamePoints = 0;
     private int totalMoves = 0;
     private int totalTeamSize = 0;
     private double averagePointsPerMatch = 0.0D;
-    private double averageEloPerMatch = 0.0D;
     private double averageTeamSize = 0.0D;
     private double elo = 100D;
     private Map<RankingAlgorithm, Integer> rankBy = Maps.newHashMap();
@@ -28,10 +26,6 @@ public class LeaderboardEntryDto {
         this.totalGames++;
     }
 
-    public void addTotalGamePoints(int amount) {
-        this.totalGamePoints += amount;
-    }
-
     public void addTotalMoves(int amount) {
         this.totalMoves += amount;
     }
@@ -40,13 +34,8 @@ public class LeaderboardEntryDto {
         this.totalTeamSize += amount;
     }
 
-    public void addElo(double normalizedElo) {
-        this.elo = Math.max(this.elo + normalizedElo, 0D);
-    }
-
     public void calculate() {
         this.averagePointsPerMatch = (double) totalPoints / (double) totalGames;
-        this.averageEloPerMatch = elo / (double) totalGames;
         this.averageTeamSize = (double) totalTeamSize / (double) totalGames;
     }
 }

--- a/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
@@ -15,6 +15,7 @@ public class LeaderboardEntryDto {
     private int totalMoves = 0;
     private int totalTeamSize = 0;
     private double averagePointsPerMatch = 0.0D;
+    private double averageEloPerMatch = 0.0D;
     private double averageTeamSize = 0.0D;
     private double elo = 0;
     private Map<RankingAlgorithm, Integer> rankBy = Maps.newHashMap();
@@ -45,6 +46,7 @@ public class LeaderboardEntryDto {
 
     public void calculate() {
         this.averagePointsPerMatch = (double) totalPoints / (double) totalGames;
+        this.averageEloPerMatch = elo / (double) totalGames;
         this.averageTeamSize = (double) totalTeamSize / (double) totalGames;
     }
 }

--- a/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
@@ -1,0 +1,17 @@
+package pro.beerpong.api.model.dto;
+
+import lombok.Data;
+import pro.beerpong.api.util.RankingAlgorithm;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class LeaderboardEntryDto {
+    private String playerId;
+    private int totalPoints;
+    private double averagePointsPerMatch;
+    private double normalizedPointsPerMatch;
+    private double elo;
+    private Map<RankingAlgorithm, Integer> rankBy;
+}

--- a/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
@@ -1,17 +1,45 @@
 package pro.beerpong.api.model.dto;
 
+import com.google.common.collect.Maps;
 import lombok.Data;
 import pro.beerpong.api.util.RankingAlgorithm;
 
-import java.util.List;
 import java.util.Map;
 
 @Data
 public class LeaderboardEntryDto {
     private String playerId;
-    private int totalPoints;
-    private double averagePointsPerMatch;
-    private double normalizedPointsPerMatch;
-    private double elo;
-    private Map<RankingAlgorithm, Integer> rankBy;
+    private int totalPoints = 0;
+    private int totalGames = 0;
+    private int totalMoves = 0;
+    private int totalTeamSize = 0;
+    private double averagePointsPerMatch = 0.0D;
+    private double averageTeamSize = 0.0D;
+    private double elo = 0;
+    private Map<RankingAlgorithm, Integer> rankBy = Maps.newHashMap();
+
+    public void addTotalPoints(int amount) {
+        this.totalPoints += amount;
+    }
+
+    public void addTotalGames() {
+        this.totalGames++;
+    }
+
+    public void addTotalMoves(int amount) {
+        this.totalMoves += amount;
+    }
+
+    public void addTotalTeamSize(int amount) {
+        this.totalTeamSize += amount;
+    }
+
+    public void addElo(double normalizedElo) {
+        this.elo += normalizedElo;
+    }
+
+    public void calculate() {
+        this.averagePointsPerMatch = (double) totalPoints / (double) totalGames;
+        this.averageTeamSize = (double) totalTeamSize / (double) totalGames;
+    }
 }

--- a/api/src/main/java/pro/beerpong/api/model/dto/MatchOverviewTeamDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/MatchOverviewTeamDto.java
@@ -7,7 +7,6 @@ import java.util.List;
 @Data
 public class MatchOverviewTeamDto {
     // total amount of points that this team made in this game
-    //TODO should pointsForTeam count only once here?
     private int points;
 
     private List<MatchOverviewTeamMemberDto> members;

--- a/api/src/main/java/pro/beerpong/api/service/GroupService.java
+++ b/api/src/main/java/pro/beerpong/api/service/GroupService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import pro.beerpong.api.mapping.GroupMapper;
 import pro.beerpong.api.model.dao.Group;
 import pro.beerpong.api.model.dao.Season;
+import pro.beerpong.api.model.dao.SeasonSettings;
 import pro.beerpong.api.model.dto.AssetMetadataDto;
 import pro.beerpong.api.model.dto.GroupCreateDto;
 import pro.beerpong.api.model.dto.GroupDto;
@@ -42,6 +43,7 @@ public class GroupService {
 
         var season = new Season();
         season.setStartDate(ZonedDateTime.now());
+        season.setSeasonSettings(new SeasonSettings());
 
         group.setActiveSeason(season);
         group = groupRepository.save(group);

--- a/api/src/main/java/pro/beerpong/api/service/GroupService.java
+++ b/api/src/main/java/pro/beerpong/api/service/GroupService.java
@@ -91,6 +91,12 @@ public class GroupService {
         return groupDto;
     }
 
+    public GroupDto getRawGroupById(String id) {
+        return groupRepository.findById(id)
+                .map(groupMapper::groupToGroupDto)
+                .orElse(null);
+    }
+
     public GroupDto updateGroup(String id, GroupCreateDto groupCreateDto) {
         return groupRepository.findById(id)
                 .map(existingGroup -> {

--- a/api/src/main/java/pro/beerpong/api/service/LeaderboardService.java
+++ b/api/src/main/java/pro/beerpong/api/service/LeaderboardService.java
@@ -45,7 +45,6 @@ public class LeaderboardService {
                 matches = matchService.streamAllMatchesInSeason(seasonId);
                 players = matchService.streamAllPlayersInSeason(seasonId);
             }
-            //TODO use season setting
             case "today" -> {
                 var season = group.getActiveSeason();
 

--- a/api/src/main/java/pro/beerpong/api/service/LeaderboardService.java
+++ b/api/src/main/java/pro/beerpong/api/service/LeaderboardService.java
@@ -1,0 +1,51 @@
+package pro.beerpong.api.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import pro.beerpong.api.mapping.SeasonMapper;
+import pro.beerpong.api.model.dao.Group;
+import pro.beerpong.api.model.dao.Season;
+import pro.beerpong.api.model.dao.SeasonSettings;
+import pro.beerpong.api.model.dto.*;
+import pro.beerpong.api.repository.GroupRepository;
+import pro.beerpong.api.repository.SeasonRepository;
+import pro.beerpong.api.sockets.SocketEvent;
+import pro.beerpong.api.sockets.SocketEventData;
+import pro.beerpong.api.sockets.SubscriptionHandler;
+import pro.beerpong.api.util.NullablePair;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class LeaderboardService {
+    private final SubscriptionHandler subscriptionHandler;
+    private final SeasonRepository seasonRepository;
+    private final GroupRepository groupRepository;
+    private final PlayerService playerService;
+    private final RuleMoveService ruleMoveService;
+    private final RuleService ruleService;
+    private final SeasonMapper seasonMapper;
+
+    @Autowired
+    public LeaderboardService(SubscriptionHandler subscriptionHandler,
+                              SeasonRepository seasonRepository,
+                              GroupRepository groupRepository,
+                              PlayerService playerService,
+                              RuleMoveService ruleMoveService,
+                              RuleService ruleService,
+                              SeasonMapper seasonMapper) {
+        this.subscriptionHandler = subscriptionHandler;
+        this.seasonRepository = seasonRepository;
+        this.groupRepository = groupRepository;
+        this.playerService = playerService;
+        this.ruleMoveService = ruleMoveService;
+        this.ruleService = ruleService;
+        this.seasonMapper = seasonMapper;
+    }
+
+
+}

--- a/api/src/main/java/pro/beerpong/api/service/LeaderboardService.java
+++ b/api/src/main/java/pro/beerpong/api/service/LeaderboardService.java
@@ -1,51 +1,166 @@
 package pro.beerpong.api.service;
 
+import com.google.api.client.util.Lists;
+import com.google.common.collect.Maps;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
-import pro.beerpong.api.mapping.SeasonMapper;
 import pro.beerpong.api.model.dao.Group;
-import pro.beerpong.api.model.dao.Season;
-import pro.beerpong.api.model.dao.SeasonSettings;
-import pro.beerpong.api.model.dto.*;
-import pro.beerpong.api.repository.GroupRepository;
-import pro.beerpong.api.repository.SeasonRepository;
-import pro.beerpong.api.sockets.SocketEvent;
-import pro.beerpong.api.sockets.SocketEventData;
-import pro.beerpong.api.sockets.SubscriptionHandler;
-import pro.beerpong.api.util.NullablePair;
+import pro.beerpong.api.model.dto.GroupDto;
+import pro.beerpong.api.model.dto.LeaderboardDto;
+import pro.beerpong.api.model.dto.LeaderboardEntryDto;
+import pro.beerpong.api.model.dto.MatchDto;
+import pro.beerpong.api.util.RankingAlgorithm;
 
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Optional;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 public class LeaderboardService {
-    private final SubscriptionHandler subscriptionHandler;
-    private final SeasonRepository seasonRepository;
-    private final GroupRepository groupRepository;
-    private final PlayerService playerService;
     private final RuleMoveService ruleMoveService;
-    private final RuleService ruleService;
-    private final SeasonMapper seasonMapper;
+    private final MatchService matchService;
 
     @Autowired
-    public LeaderboardService(SubscriptionHandler subscriptionHandler,
-                              SeasonRepository seasonRepository,
-                              GroupRepository groupRepository,
-                              PlayerService playerService,
-                              RuleMoveService ruleMoveService,
-                              RuleService ruleService,
-                              SeasonMapper seasonMapper) {
-        this.subscriptionHandler = subscriptionHandler;
-        this.seasonRepository = seasonRepository;
-        this.groupRepository = groupRepository;
-        this.playerService = playerService;
+    public LeaderboardService(RuleMoveService ruleMoveService, MatchService matchService) {
         this.ruleMoveService = ruleMoveService;
-        this.ruleService = ruleService;
-        this.seasonMapper = seasonMapper;
+        this.matchService = matchService;
     }
 
+    public LeaderboardDto generateLeaderboard(GroupDto group, String scope, @Nullable String seasonId) {
+        Stream<MatchDto> matches;
 
+        switch (scope) {
+            case "all-time" -> matches = matchService.streamAllMatches(group);
+            case "season" -> {
+                if (seasonId == null) {
+                    return null;
+                }
+
+                matches = matchService.streamAllMatchesInSeason(seasonId);
+            }
+            case "daily" -> matches = matchService.streamAllMatchesToday(group);
+            default -> matches = Stream.of();
+        }
+
+        Map<String, LeaderboardEntryDto> entries = Maps.newHashMap();
+
+        // go through all matches and all teams
+        matches.forEach(matchDto -> matchDto.getTeams().forEach(teamDto -> {
+            // collect team members
+            var teamMembers = matchDto.getTeamMembers().stream()
+                    .filter(teamMemberDto -> teamMemberDto.getTeamId().equals(teamDto.getId()))
+                    .collect(Collectors.toCollection(Lists::newArrayList));
+
+            // go through all team members
+            teamMembers.forEach(teamMemberDto -> {
+                // create leaderboard entries for all members
+                if (!entries.containsKey(teamMemberDto.getId())) {
+                    var dto = new LeaderboardEntryDto();
+
+                    dto.setPlayerId(teamMemberDto.getPlayerId());
+
+                    entries.put(teamMemberDto.getId(), dto);
+                }
+
+                // add game and team size to entry
+                entries.get(teamMemberDto.getId()).addTotalGames();
+                entries.get(teamMemberDto.getId()).addTotalTeamSize(teamMembers.size());
+            });
+
+            AtomicInteger teamPoints = new AtomicInteger();
+            Map<String, Integer> pointsPerPlayer = Maps.newHashMap();
+
+            // go through all moves made by this team
+            matchDto.getMatchMoves().stream()
+                    .filter(dto -> teamMembers.stream().anyMatch(teamMemberDto -> teamMemberDto.getId().equals(dto.getTeamMemberId())))
+                    .forEach(dto -> {
+                        if (!entries.containsKey(dto.getTeamMemberId())) {
+                            return;
+                        }
+
+                        // get entry and points for this move
+                        var entry = entries.get(dto.getTeamMemberId());
+                        var points = ruleMoveService.getPointsById(dto.getMoveId());
+
+                        if (points == null) {
+                            return;
+                        }
+
+                        // save points for player and points for team to calculate activity
+                        // here we don't include the pointsForTeam because everybody in the team receives those
+                        pointsPerPlayer.put(dto.getTeamMemberId(), pointsPerPlayer.getOrDefault(dto.getTeamMemberId(), 0) +
+                                (points.getFirst() * dto.getValue()));
+                        // add points to teamPoints if they are not a move that gains the whole team points
+                        // to reward the player that made the move, without punishing his members for this,
+                        // we don't add those points here but to the players points
+                        teamPoints.addAndGet((points.getSecond() == 0 ? points.getFirst() * dto.getValue() : 0));
+
+                        // add total moves and gained points to the scorers entry
+                        entry.addTotalMoves(dto.getValue());
+                        entry.addTotalPoints(points.getFirst() * dto.getValue());
+
+                        // if pointsForTeam > 0 add gained pointsForTeam to every team members entry
+                        if (points.getSecond() > 0) {
+                            teamMembers.forEach(teamMemberDto -> {
+                                if (entries.containsKey(teamMemberDto.getId())) {
+                                    entries.get(teamMemberDto.getId()).addTotalPoints(points.getSecond() * dto.getValue());
+                                }
+                            });
+                        }
+                    });
+
+            // calculate stats for all members
+            teamMembers.forEach(teamMemberDto -> {
+                if (entries.containsKey(teamMemberDto.getId())) {
+                    return;
+                }
+
+                // get points the player made and points the team made
+                var playerPoints = pointsPerPlayer.getOrDefault(teamMemberDto.getId(), 0);
+                var teamSize = teamMembers.size();
+
+                // calculate the activity of the player based on the ratio of player points to team points
+                double activityWeight = (double) playerPoints / teamPoints.get();
+                // normalize the amount of points the player made
+                double normalizedScore = (playerPoints / (double) teamSize) * activityWeight;
+
+                // add normalized score to players score
+                entries.get(teamMemberDto.getId()).addElo(normalizedScore);
+            });
+
+            // clear team member cache
+            teamMembers.clear();
+        }));
+
+        // calculate averages for all entries
+        entries.values().forEach(LeaderboardEntryDto::calculate);
+
+        // create dto and set entries
+        var dto = new LeaderboardDto();
+        dto.setEntries(Lists.newArrayList(entries.values()));
+
+        // calculate ranking for all possible algorithms
+        for (RankingAlgorithm value : RankingAlgorithm.values()) {
+            var ranking = new AtomicInteger();
+
+            var stream = dto.getEntries().stream();
+
+            // sort the stream based on the current algorithm
+            switch (value) {
+                case AVERAGE -> stream = stream.sorted(Comparator.comparing(LeaderboardEntryDto::getAveragePointsPerMatch));
+                case ELO -> stream = stream.sorted(Comparator.comparing(LeaderboardEntryDto::getElo));
+            }
+
+            // set ranking for current algorithm
+            stream.forEach(entry -> entry.getRankBy().put(value, ranking.incrementAndGet()));
+        }
+
+        // clear entries
+        entries.clear();
+
+        return dto;
+    }
 }

--- a/api/src/main/java/pro/beerpong/api/service/LeaderboardService.java
+++ b/api/src/main/java/pro/beerpong/api/service/LeaderboardService.java
@@ -5,9 +5,13 @@ import com.google.common.collect.Maps;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
-import pro.beerpong.api.model.dto.*;
+import pro.beerpong.api.model.dto.GroupDto;
+import pro.beerpong.api.model.dto.LeaderboardDto;
+import pro.beerpong.api.model.dto.LeaderboardEntryDto;
+import pro.beerpong.api.model.dto.MatchDto;
 import pro.beerpong.api.util.RankingAlgorithm;
 
+import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -18,11 +22,8 @@ public class LeaderboardService {
     private final RuleMoveService ruleMoveService;
     private final MatchService matchService;
 
-    private static final double CONTRIBUTION_WEIGHT = 5.0D;
-    private static final double TEAM_IMPACT_WEIGHT = 0.3D;
-    private static final double PLAYER_IMPACT_WEIGHT = 0.3D;
-    private static final double EFFICIENCY_WEIGHT = 0.3D;
-    private static final double TEAM_SIZE_WEIGHT = 0.2D;
+    private static final double K_FACTOR = 32D;
+    private static final int ELO_DIVIDER = 400;
 
     @Autowired
     public LeaderboardService(RuleMoveService ruleMoveService, MatchService matchService) {
@@ -52,123 +53,117 @@ public class LeaderboardService {
 
         //TODO create entries for all player in current season, provided season or all time
 
-        // go through all matches and all teams
-        matches.forEach(matchDto -> matchDto.getTeams().forEach(teamDto -> {
-            // collect team members
-            var teamMembers = matchDto.getTeamMembers().stream()
-                    .filter(teamMemberDto -> teamMemberDto.getTeamId().equals(teamDto.getId()))
-                    .collect(Collectors.toCollection(Lists::newArrayList));
+        // go through all matches sorted by date, starting with the earliest
+        matches.sorted(Comparator.comparing(MatchDto::getDate)).forEach(matchDto -> {
+            if (matchDto.getTeams().size() < 2) {
+                return;
+            }
 
-            // go through all team members
-            teamMembers.forEach(teamMemberDto -> {
-                // create leaderboard entries for all members
-                if (!entries.containsKey(teamMemberDto.getPlayerId())) {
-                    var dto = new LeaderboardEntryDto();
+            // go through all teams
+            matchDto.getTeams().forEach(teamDto -> {
+                // collect team members
+                var teamMembers = matchDto.getTeamMembers().stream()
+                        .filter(teamMemberDto -> teamMemberDto.getTeamId().equals(teamDto.getId()))
+                        .collect(Collectors.toCollection(Lists::newArrayList));
 
-                    dto.setPlayerId(teamMemberDto.getPlayerId());
+                // go through all team members
+                teamMembers.forEach(teamMemberDto -> {
+                    // create leaderboard entries for all members
+                    if (!entries.containsKey(teamMemberDto.getPlayerId())) {
+                        var dto = new LeaderboardEntryDto();
 
-                    entries.put(teamMemberDto.getPlayerId(), dto);
-                }
+                        dto.setPlayerId(teamMemberDto.getPlayerId());
 
-                // save player id by member id
-                if (!memberToPlayer.containsKey(teamMemberDto.getTeamId())) {
-                    memberToPlayer.put(teamMemberDto.getId(), teamMemberDto.getPlayerId());
-                }
+                        entries.put(teamMemberDto.getPlayerId(), dto);
+                    }
 
-                // add game and team size to entry
-                entries.get(teamMemberDto.getPlayerId()).addTotalGames();
-                entries.get(teamMemberDto.getPlayerId()).addTotalTeamSize(teamMembers.size());
+                    // save player id by member id
+                    if (!memberToPlayer.containsKey(teamMemberDto.getTeamId())) {
+                        memberToPlayer.put(teamMemberDto.getId(), teamMemberDto.getPlayerId());
+                    }
+
+                    // add game and team size to entry
+                    entries.get(teamMemberDto.getPlayerId()).addTotalGames();
+                    entries.get(teamMemberDto.getPlayerId()).addTotalTeamSize(teamMembers.size());
+                });
+
+                AtomicInteger teamPoints = new AtomicInteger();
+                Map<String, Integer> pointsPerPlayer = Maps.newHashMap();
+
+                // go through all moves made by this team
+                matchDto.getMatchMoves().stream()
+                        .filter(dto -> teamMembers.stream().anyMatch(teamMemberDto -> teamMemberDto.getId().equals(dto.getTeamMemberId())))
+                        .forEach(dto -> {
+                            if (!memberToPlayer.containsKey(dto.getTeamMemberId()) ||
+                                    !entries.containsKey(memberToPlayer.get(dto.getTeamMemberId()))) {
+                                return;
+                            }
+
+                            // get entry and points for this move
+                            var entry = entries.get(memberToPlayer.get(dto.getTeamMemberId()));
+                            var points = ruleMoveService.getPointsById(dto.getMoveId());
+
+                            if (points == null) {
+                                return;
+                            }
+
+                            // save points for player and points for team to calculate activity
+                            // here we don't include the pointsForTeam because everybody in the team receives those
+                            pointsPerPlayer.put(dto.getTeamMemberId(), pointsPerPlayer.getOrDefault(dto.getTeamMemberId(), 0) +
+                                    (points.getFirst() * dto.getValue()));
+                            // add points to teamPoints if they are not a move that gains the whole team points
+                            // to reward the player that made the move, without punishing his members for this,
+                            // we don't add those points here but to the players points
+                            teamPoints.addAndGet((points.getSecond() == 0 ? points.getFirst() * dto.getValue() : 0));
+
+                            // add total moves and gained points to the scorers entry
+                            entry.addTotalMoves(dto.getValue());
+                            entry.addTotalPoints(points.getFirst() * dto.getValue());
+
+                            // if pointsForTeam > 0 add gained pointsForTeam to every team members entry
+                            if (points.getSecond() > 0) {
+                                teamMembers.forEach(teamMemberDto -> {
+                                    if (entries.containsKey(teamMemberDto.getPlayerId())) {
+                                        entries.get(teamMemberDto.getPlayerId()).addTotalPoints(points.getSecond() * dto.getValue());
+                                    }
+                                });
+                            }
+                        });
+
+                // clear team member cache
+                teamMembers.clear();
             });
 
-            AtomicInteger teamPoints = new AtomicInteger();
-            Map<String, Integer> pointsPerPlayer = Maps.newHashMap();
+            // find the move that ended the game -> to find the winning team
+            var winningMove = matchDto.getMatchMoves().stream()
+                    .filter(dtoComplete -> ruleMoveService.isFinish(dtoComplete.getMoveId()))
+                    .findFirst()
+                    .orElse(null);
 
-            // go through all moves made by this team
-            matchDto.getMatchMoves().stream()
-                    .filter(dto -> teamMembers.stream().anyMatch(teamMemberDto -> teamMemberDto.getId().equals(dto.getTeamMemberId())))
-                    .forEach(dto -> {
-                        if (!memberToPlayer.containsKey(dto.getTeamMemberId()) ||
-                                !entries.containsKey(memberToPlayer.get(dto.getTeamMemberId()))) {
-                            return;
-                        }
+            if (winningMove == null) {
+                // no winning move? weird...
+                return;
+            }
 
-                        // get entry and points for this move
-                        var entry = entries.get(memberToPlayer.get(dto.getTeamMemberId()));
-                        var points = ruleMoveService.getPointsById(dto.getMoveId());
+            // calculate team elos
+            var team1Elo = matchDto.getTeamMembers().stream()
+                    .filter(teamMemberDto -> teamMemberDto.getTeamId().equals(matchDto.getTeams().getFirst().getId()) && entries.containsKey(teamMemberDto.getPlayerId()))
+                    .map(teamMemberDto -> entries.get(teamMemberDto.getPlayerId()).getElo())
+                    .reduce(Double::sum)
+                    .orElse(0D);
+            var team2Elo = matchDto.getTeamMembers().stream()
+                    .filter(teamMemberDto -> teamMemberDto.getTeamId().equals(matchDto.getTeams().get(1).getId()) && entries.containsKey(teamMemberDto.getPlayerId()))
+                    .map(teamMemberDto -> entries.get(teamMemberDto.getPlayerId()).getElo())
+                    .reduce(Double::sum)
+                    .orElse(0D);
 
-                        if (points == null) {
-                            return;
-                        }
-
-                        // save points for player and points for team to calculate activity
-                        // here we don't include the pointsForTeam because everybody in the team receives those
-                        pointsPerPlayer.put(dto.getTeamMemberId(), pointsPerPlayer.getOrDefault(dto.getTeamMemberId(), 0) +
-                                (points.getFirst() * dto.getValue()));
-                        // add points to teamPoints if they are not a move that gains the whole team points
-                        // to reward the player that made the move, without punishing his members for this,
-                        // we don't add those points here but to the players points
-                        teamPoints.addAndGet((points.getSecond() == 0 ? points.getFirst() * dto.getValue() : 0));
-
-                        // add total moves and gained points to the scorers entry
-                        entry.addTotalMoves(dto.getValue());
-                        entry.addTotalPoints(points.getFirst() * dto.getValue());
-
-                        // if pointsForTeam > 0 add gained pointsForTeam to every team members entry
-                        if (points.getSecond() > 0) {
-                            teamMembers.forEach(teamMemberDto -> {
-                                if (entries.containsKey(teamMemberDto.getPlayerId())) {
-                                    entries.get(teamMemberDto.getPlayerId()).addTotalPoints(points.getSecond() * dto.getValue());
-                                }
-                            });
-                        }
-                    });
-
-            // calculate stats for all members
-            teamMembers.forEach(teamMemberDto -> {
-                if (!entries.containsKey(teamMemberDto.getPlayerId())) {
-                    return;
-                }
-
-                var entry = entries.get(teamMemberDto.getPlayerId());
-
-                // get points the player made and points the team made
-                var playerPoints = pointsPerPlayer.getOrDefault(teamMemberDto.getId(), 0);
-                var teamSize = teamMembers.size();
-
-                // how many of the teams points the player made
-                double contributionRatio  = (double) playerPoints / teamPoints.get();
-
-                // how many points the player made per move
-                double pointsPerMove = (double) playerPoints / matchDto.getMatchMoves().stream()
-                        .filter(dtoComplete -> dtoComplete.getTeamMemberId().equals(teamMemberDto.getId()))
-                        .map(MatchMoveDtoComplete::getValue)
-                        .reduce(Integer::sum)
-                        .orElse(playerPoints);
-
-                // reward larger teams
-                double teamSizeFactor = 1.0 / teamSize;
-
-                // reward higher amounts of team points
-                double impactOfTeam = Math.log(teamPoints.get() + 1);
-
-                // reward higher amounts of player points
-                double impactOnTeam = Math.log(playerPoints + 1);
-
-                // calculate weighted elo
-                double elo = (CONTRIBUTION_WEIGHT * contributionRatio) +
-                        (EFFICIENCY_WEIGHT * pointsPerMove) +
-                        (TEAM_SIZE_WEIGHT * teamSizeFactor) +
-                        (TEAM_IMPACT_WEIGHT * impactOfTeam) //+
-                        //(PLAYER_IMPACT_WEIGHT * impactOnTeam)
-                        ;
-
-                // add normalized score to players score
-                entry.addElo(elo);
+            // calculate elo for all team members
+            matchDto.getTeamMembers().forEach(teamMemberDto -> {
+                var score = 1.0D; // win: 1, draw: 0.5, loss: 0.0
+                var expected = expectedScore(team1Elo, team2Elo);
+                var newRating = team1Elo + K_FACTOR * (score - expected);
             });
-
-            // clear team member cache
-            teamMembers.clear();
-        }));
+        });
 
         // calculate averages for all entries
         entries.values().forEach(LeaderboardEntryDto::calculate);
@@ -185,7 +180,8 @@ public class LeaderboardService {
 
             // sort the stream based on the current algorithm
             switch (value) {
-                case AVERAGE -> stream = stream.sorted((o1, o2) -> Double.compare(o2.getAveragePointsPerMatch(), o1.getAveragePointsPerMatch()));
+                case AVERAGE ->
+                        stream = stream.sorted((o1, o2) -> Double.compare(o2.getAveragePointsPerMatch(), o1.getAveragePointsPerMatch()));
                 case ELO -> stream = stream.sorted((o1, o2) -> Double.compare(o2.getElo(), o1.getElo()));
             }
 
@@ -198,4 +194,10 @@ public class LeaderboardService {
 
         return dto;
     }
+
+    private double expectedScore(double elo1, double elo2) {
+        return 1.0 / (1 + Math.pow(10, (elo2 - elo1) / ELO_DIVIDER));
+    }
+
+
 }

--- a/api/src/main/java/pro/beerpong/api/service/MatchService.java
+++ b/api/src/main/java/pro/beerpong/api/service/MatchService.java
@@ -35,6 +35,7 @@ public class MatchService {
 
     private final TeamService teamService;
     private final SeasonRepository seasonRepository;
+    private final RuleMoveService ruleMoveService;
 
     @Autowired
     public MatchService(SubscriptionHandler subscriptionHandler,
@@ -47,7 +48,7 @@ public class MatchService {
                         MatchMoveRepository matchMoveRepository,
                         RuleMoveRepository ruleMoveRepository,
                         MatchMoveMapper matchMoveMapper,
-                        TeamService teamService, SeasonRepository seasonRepository) {
+                        TeamService teamService, SeasonRepository seasonRepository, RuleMoveService ruleMoveService) {
         this.subscriptionHandler = subscriptionHandler;
 
         this.matchRepository = matchRepository;
@@ -62,6 +63,7 @@ public class MatchService {
 
         this.teamService = teamService;
         this.seasonRepository = seasonRepository;
+        this.ruleMoveService = ruleMoveService;
     }
 
     private boolean validateCreateDto(String groupId, String seasonId, MatchCreateDto dto) {
@@ -77,7 +79,9 @@ public class MatchService {
                         var move = ruleMoveRepository.findById(matchMoveDto.getMoveId());
 
                         return move.isPresent() && move.get().getSeason().getId().equals(seasonId) && move.get().getSeason().getGroupId().equals(groupId);
-                    });
+                    }) && memberDto.getMoves().stream()
+                            .filter(matchMoveDto -> ruleMoveService.isFinish(matchMoveDto.getMoveId()))
+                            .count() == 1;
                 }));
     }
 

--- a/api/src/main/java/pro/beerpong/api/service/MatchService.java
+++ b/api/src/main/java/pro/beerpong/api/service/MatchService.java
@@ -90,7 +90,7 @@ public class MatchService {
                 dto.getTeams().stream()
                         .flatMap(teamCreateDto -> teamCreateDto.getTeamMembers().stream())
                         .flatMap(memberCreateDto -> memberCreateDto.getMoves().stream())
-                        .filter(matchMoveDto -> ruleMoveService.isFinish(matchMoveDto.getMoveId()))
+                        .filter(matchMoveDto -> ruleMoveService.isFinish(matchMoveDto.getMoveId()) && matchMoveDto.getCount() == 1)
                         .count() != 1;
     }
 

--- a/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
+++ b/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
@@ -96,6 +96,12 @@ public class RuleMoveService {
                 .orElse(Pair.of(0, 0));
     }
 
+    public boolean isFinish(String ruleMoveId) {
+        return moveRepository.findById(ruleMoveId)
+                .map(RuleMove::isFinishingMove)
+                .orElse(false);
+    }
+
     public RuleMoveDto getById(String ruleMoveId) {
         return moveRepository.findById(ruleMoveId)
                 .map(moveMapper::ruleMoveToRuleMoveDto)

--- a/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
+++ b/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
@@ -1,6 +1,7 @@
 package pro.beerpong.api.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import pro.beerpong.api.mapping.RuleMoveMapper;
 import pro.beerpong.api.model.dao.Group;
@@ -87,6 +88,12 @@ public class RuleMoveService {
                 })
                 .orElse(false);
 
+    }
+
+    public Pair<Integer, Integer> getPointsById(String ruleMoveId) {
+        return moveRepository.findById(ruleMoveId)
+                .map(ruleMove -> Pair.of(ruleMove.getPointsForScorer(), ruleMove.getPointsForTeam()))
+                .orElse(Pair.of(0, 0));
     }
 
     public RuleMoveDto getById(String ruleMoveId) {

--- a/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
+++ b/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
@@ -22,10 +22,10 @@ import java.util.Optional;
 public class RuleMoveService {
     private static final List<RuleMove> DEFAULT_RULE_MOVES = List.of(
             buildRuleMove("Normal", 1, 0, false),
-            buildRuleMove("Bomb", 1, 0, false),
-            buildRuleMove("Bouncer", 1, 0, false),
-            buildRuleMove("Trickshot", 1, 0, false),
-            buildRuleMove("Save", 1, 0, false),
+            buildRuleMove("Bomb", 2, 0, false),
+            buildRuleMove("Bouncer", 2, 0, false),
+            buildRuleMove("Trickshot", 2, 0, false),
+            buildRuleMove("Save", 2, 0, false),
             buildRuleMove("Finish - Normal", 0, 3, true),
             buildRuleMove("Finish - Ring of fire", 0, 10, true)
     );

--- a/api/src/main/java/pro/beerpong/api/service/SeasonService.java
+++ b/api/src/main/java/pro/beerpong/api/service/SeasonService.java
@@ -108,6 +108,8 @@ public class SeasonService {
                         existingSeason.getSeasonSettings().setMinTeamSize(dto.getSeasonSettings().getMinTeamSize());
                         existingSeason.getSeasonSettings().setMinMatchesToQualify(dto.getSeasonSettings().getMinMatchesToQualify());
                         existingSeason.getSeasonSettings().setRankingAlgorithm(dto.getSeasonSettings().getRankingAlgorithm());
+                        existingSeason.getSeasonSettings().setDailyLeaderboard(dto.getSeasonSettings().getDailyLeaderboard());
+                        existingSeason.getSeasonSettings().setWakeTimeHour(dto.getSeasonSettings().getWakeTimeHour());
                     }
 
                     var seasonDto = seasonMapper.seasonToSeasonDto(seasonRepository.save(existingSeason));

--- a/api/src/main/java/pro/beerpong/api/service/SeasonService.java
+++ b/api/src/main/java/pro/beerpong/api/service/SeasonService.java
@@ -67,6 +67,8 @@ public class SeasonService {
             season.getSeasonSettings().setMinTeamSize(oldSeason.getSeasonSettings().getMinTeamSize());
             season.getSeasonSettings().setMinMatchesToQualify(oldSeason.getSeasonSettings().getMinMatchesToQualify());
             season.getSeasonSettings().setRankingAlgorithm(oldSeason.getSeasonSettings().getRankingAlgorithm());
+            season.getSeasonSettings().setDailyLeaderboard(oldSeason.getSeasonSettings().getDailyLeaderboard());
+            season.getSeasonSettings().setWakeTimeHour(oldSeason.getSeasonSettings().getWakeTimeHour());
         }
 
         season = seasonRepository.save(season);

--- a/api/src/main/java/pro/beerpong/api/sockets/SubscriptionHandler.java
+++ b/api/src/main/java/pro/beerpong/api/sockets/SubscriptionHandler.java
@@ -82,8 +82,7 @@ public class SubscriptionHandler extends TextWebSocketHandler {
     }
 
     public void callEvent(SocketEvent<?> event) {
-        //TODO remove event body
-        LOGGER.debug("SOCKETS: Calling {} event for group {}: {}", event.getScope(), event.getGroupId(), GSON.toJson(event.getBody()));
+        LOGGER.debug("SOCKETS: Calling {} event for group {}", event.getScope(), event.getGroupId());
 
         if (!groupSessions.containsKey(event.getGroupId())) {
             return;

--- a/api/src/main/java/pro/beerpong/api/util/DailyLeaderboard.java
+++ b/api/src/main/java/pro/beerpong/api/util/DailyLeaderboard.java
@@ -1,0 +1,11 @@
+package pro.beerpong.api.util;
+
+public enum DailyLeaderboard {
+    RESET_AT_MIDNIGHT,
+    WAKE_TIME,
+    LAST_24_HOURS;
+
+    public String getId() {
+        return this.name().toLowerCase();
+    }
+}

--- a/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
+++ b/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
@@ -95,19 +95,33 @@ public class CreateMatchTest {
         createRulemMoveDto.setFinishingMove(false);
         createRulemMoveDto.setPointsForTeam(0);
         createRulemMoveDto.setPointsForScorer(1);
+        var createRulemMoveDto1 = new RuleMoveCreateDto();
+        createRulemMoveDto1.setName("RuleMove2");
+        createRulemMoveDto1.setFinishingMove(true);
+        createRulemMoveDto1.setPointsForTeam(1);
+        createRulemMoveDto1.setPointsForScorer(1);
 
         var ruleMoveResponse = testUtils.performPost(port, "/groups/" + group.getId() + "/seasons/" + season.getId() + "/rule-moves", createRulemMoveDto, RuleMoveDto.class);
+        var ruleMoveResponse1 = testUtils.performPost(port, "/groups/" + group.getId() + "/seasons/" + season.getId() + "/rule-moves", createRulemMoveDto1, RuleMoveDto.class);
 
         assertNotNull(ruleMoveResponse);
+        assertNotNull(ruleMoveResponse1);
         assertEquals(200, ruleMoveResponse.getStatusCode().value());
+        assertEquals(200, ruleMoveResponse1.getStatusCode().value());
 
         ResponseEnvelope<RuleMoveDto> ruleMoveEnvelope = (ResponseEnvelope<RuleMoveDto>) ruleMoveResponse.getBody();
+        ResponseEnvelope<RuleMoveDto> ruleMoveEnvelope1 = (ResponseEnvelope<RuleMoveDto>) ruleMoveResponse1.getBody();
         assertNotNull(ruleMoveEnvelope);
+        assertNotNull(ruleMoveEnvelope1);
         assertEquals(ResponseEnvelope.Status.OK, ruleMoveEnvelope.getStatus());
+        assertEquals(ResponseEnvelope.Status.OK, ruleMoveEnvelope1.getStatus());
         assertNull(ruleMoveEnvelope.getError());
+        assertNull(ruleMoveEnvelope1.getError());
         assertEquals(200, ruleMoveEnvelope.getHttpCode());
+        assertEquals(200, ruleMoveEnvelope1.getHttpCode());
 
         var ruleMove = ruleMoveEnvelope.getData();
+        var ruleMove1 = ruleMoveEnvelope1.getData();
 
         // Arrange: Erstelle ein MatchCreateDto mit Teams, TeamMembers und Moves
         MatchCreateDto matchCreateDto = new MatchCreateDto();
@@ -125,7 +139,11 @@ public class CreateMatchTest {
         move2.setMoveId(ruleMove.getId());
         move2.setCount(5);
 
-        member1.setMoves(List.of(move1, move2));
+        MatchMoveDto move7 = new MatchMoveDto();
+        move7.setMoveId(ruleMove1.getId());
+        move7.setCount(1);
+
+        member1.setMoves(List.of(move1, move2, move7));
 
         TeamMemberCreateDto member2 = new TeamMemberCreateDto();
         member2.setPlayerId(players.get(1).getId());
@@ -199,10 +217,16 @@ public class CreateMatchTest {
         // Step 2: Create a rule move
         var createRuleMoveDto = new RuleMoveDto();
         createRuleMoveDto.setName("UpdateRuleMove");
+        var createRuleMoveDto1 = new RuleMoveDto();
+        createRuleMoveDto1.setName("UpdateRuleMove");
+        createRuleMoveDto1.setFinishingMove(true);
 
         var ruleMoveResponse = testUtils.performPost(port, "/groups/" + group.getId() + "/seasons/" + season.getId() + "/rule-moves", createRuleMoveDto, RuleMoveDto.class);
+        var ruleMoveResponse1 = testUtils.performPost(port, "/groups/" + group.getId() + "/seasons/" + season.getId() + "/rule-moves", createRuleMoveDto1, RuleMoveDto.class);
         ResponseEnvelope<RuleMoveDto> ruleMoveEnvelope = (ResponseEnvelope<RuleMoveDto>) ruleMoveResponse.getBody();
+        ResponseEnvelope<RuleMoveDto> ruleMoveEnvelope1 = (ResponseEnvelope<RuleMoveDto>) ruleMoveResponse1.getBody();
         var ruleMove = ruleMoveEnvelope.getData();
+        var ruleMove1 = ruleMoveEnvelope1.getData();
 
         // Step 3: Create a match with teams and members
         MatchCreateDto matchCreateDto = new MatchCreateDto();
@@ -212,8 +236,8 @@ public class CreateMatchTest {
         TeamMemberCreateDto member1 = new TeamMemberCreateDto();
         member1.setPlayerId(players.get(0).getId());
         MatchMoveDto move1 = new MatchMoveDto();
-        move1.setMoveId(ruleMove.getId());
-        move1.setCount(3);
+        move1.setMoveId(ruleMove1.getId());
+        move1.setCount(1);
         member1.setMoves(List.of(move1));
         team1.setTeamMembers(List.of(member1));
 

--- a/mobile-app/api/generated/openapi.json
+++ b/mobile-app/api/generated/openapi.json
@@ -967,6 +967,44 @@
                 }
             }
         },
+        "/groups/{groupId}/leaderboard": {
+            "get": {
+                "tags": ["leaderboard-controller"],
+                "operationId": "getLeaderboard",
+                "parameters": [
+                    {
+                        "name": "groupId",
+                        "in": "path",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    },
+                    {
+                        "name": "scope",
+                        "in": "query",
+                        "required": true,
+                        "schema": { "type": "string" }
+                    },
+                    {
+                        "name": "seasonId",
+                        "in": "query",
+                        "required": false,
+                        "schema": { "type": "string" }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseEnvelopeLeaderboardDto"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/assets/{id}": {
             "get": {
                 "tags": ["asset-controller"],
@@ -1134,7 +1172,16 @@
                     "rankingAlgorithm": {
                         "type": "string",
                         "enum": ["AVERAGE", "ELO"]
-                    }
+                    },
+                    "dailyLeaderboard": {
+                        "type": "string",
+                        "enum": [
+                            "RESET_AT_MIDNIGHT",
+                            "WAKE_TIME",
+                            "LAST_24_HOURS"
+                        ]
+                    },
+                    "wakeTimeHour": { "type": "integer", "format": "int32" }
                 }
             },
             "ResponseEnvelopeAssetMetadataDto": {
@@ -1502,6 +1549,49 @@
                         "type": "array",
                         "items": { "$ref": "#/components/schemas/ProfileDto" }
                     },
+                    "error": { "$ref": "#/components/schemas/ErrorDetails" }
+                }
+            },
+            "LeaderboardDto": {
+                "type": "object",
+                "properties": {
+                    "entries": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/LeaderboardEntryDto"
+                        }
+                    }
+                }
+            },
+            "LeaderboardEntryDto": {
+                "type": "object",
+                "properties": {
+                    "playerId": { "type": "string" },
+                    "totalPoints": { "type": "integer", "format": "int32" },
+                    "totalGames": { "type": "integer", "format": "int32" },
+                    "totalMoves": { "type": "integer", "format": "int32" },
+                    "totalTeamSize": { "type": "integer", "format": "int32" },
+                    "averagePointsPerMatch": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "averageTeamSize": { "type": "number", "format": "double" },
+                    "elo": { "type": "number", "format": "double" },
+                    "rankBy": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    }
+                }
+            },
+            "ResponseEnvelopeLeaderboardDto": {
+                "type": "object",
+                "properties": {
+                    "status": { "type": "string", "enum": ["OK", "ERROR"] },
+                    "httpCode": { "type": "integer", "format": "int32" },
+                    "data": { "$ref": "#/components/schemas/LeaderboardDto" },
                     "error": { "$ref": "#/components/schemas/ErrorDetails" }
                 }
             }

--- a/mobile-app/openapi/openapi.d.ts
+++ b/mobile-app/openapi/openapi.d.ts
@@ -32,6 +32,22 @@ declare namespace Components {
             numberOfMatches?: number; // int32
             numberOfSeasons?: number; // int32
         }
+        export interface LeaderboardDto {
+            entries?: LeaderboardEntryDto[];
+        }
+        export interface LeaderboardEntryDto {
+            playerId?: string;
+            totalPoints?: number; // int32
+            totalGames?: number; // int32
+            totalMoves?: number; // int32
+            totalTeamSize?: number; // int32
+            averagePointsPerMatch?: number; // double
+            averageTeamSize?: number; // double
+            elo?: number; // double
+            rankBy?: {
+                [name: string]: number; // int32
+            };
+        }
         export interface MatchCreateDto {
             teams?: TeamCreateDto[];
         }
@@ -98,6 +114,12 @@ declare namespace Components {
             status?: 'OK' | 'ERROR';
             httpCode?: number; // int32
             data?: GroupDto;
+            error?: ErrorDetails;
+        }
+        export interface ResponseEnvelopeLeaderboardDto {
+            status?: 'OK' | 'ERROR';
+            httpCode?: number; // int32
+            data?: LeaderboardDto;
             error?: ErrorDetails;
         }
         export interface ResponseEnvelopeListMatchDto {
@@ -227,6 +249,11 @@ declare namespace Components {
             minTeamSize?: number; // int32
             maxTeamSize?: number; // int32
             rankingAlgorithm?: 'AVERAGE' | 'ELO';
+            dailyLeaderboard?:
+                | 'RESET_AT_MIDNIGHT'
+                | 'WAKE_TIME'
+                | 'LAST_24_HOURS';
+            wakeTimeHour?: number; // int32
         }
         export interface SeasonUpdateDto {
             seasonSettings: SeasonSettings;
@@ -426,6 +453,24 @@ declare namespace Paths {
     namespace GetHealthcheck {
         namespace Responses {
             export type $200 = Components.Schemas.ResponseEnvelopeString;
+        }
+    }
+    namespace GetLeaderboard {
+        namespace Parameters {
+            export type GroupId = string;
+            export type Scope = string;
+            export type SeasonId = string;
+        }
+        export interface PathParameters {
+            groupId: Parameters.GroupId;
+        }
+        export interface QueryParameters {
+            scope: Parameters.Scope;
+            seasonId?: Parameters.SeasonId;
+        }
+        namespace Responses {
+            export type $200 =
+                Components.Schemas.ResponseEnvelopeLeaderboardDto;
         }
     }
     namespace GetMatchById {
@@ -876,6 +921,17 @@ export interface OperationMethods {
         config?: AxiosRequestConfig
     ): OperationResponse<Paths.GetAllMatchOverviews.Responses.$200>;
     /**
+     * getLeaderboard
+     */
+    'getLeaderboard'(
+        parameters?: Parameters<
+            Paths.GetLeaderboard.QueryParameters &
+                Paths.GetLeaderboard.PathParameters
+        > | null,
+        data?: any,
+        config?: AxiosRequestConfig
+    ): OperationResponse<Paths.GetLeaderboard.Responses.$200>;
+    /**
      * getAsset
      */
     'getAsset'(
@@ -1162,6 +1218,19 @@ export interface PathsDictionary {
             config?: AxiosRequestConfig
         ): OperationResponse<Paths.GetAllMatchOverviews.Responses.$200>;
     };
+    ['/groups/{groupId}/leaderboard']: {
+        /**
+         * getLeaderboard
+         */
+        'get'(
+            parameters?: Parameters<
+                Paths.GetLeaderboard.QueryParameters &
+                    Paths.GetLeaderboard.PathParameters
+            > | null,
+            data?: any,
+            config?: AxiosRequestConfig
+        ): OperationResponse<Paths.GetLeaderboard.Responses.$200>;
+    };
     ['/assets/{id}']: {
         /**
          * getAsset
@@ -1200,6 +1269,8 @@ export type AssetMetadataDto = Components.Schemas.AssetMetadataDto;
 export type ErrorDetails = Components.Schemas.ErrorDetails;
 export type GroupCreateDto = Components.Schemas.GroupCreateDto;
 export type GroupDto = Components.Schemas.GroupDto;
+export type LeaderboardDto = Components.Schemas.LeaderboardDto;
+export type LeaderboardEntryDto = Components.Schemas.LeaderboardEntryDto;
 export type MatchCreateDto = Components.Schemas.MatchCreateDto;
 export type MatchDto = Components.Schemas.MatchDto;
 export type MatchMoveDto = Components.Schemas.MatchMoveDto;
@@ -1216,6 +1287,8 @@ export type ResponseEnvelopeAssetMetadataDto =
     Components.Schemas.ResponseEnvelopeAssetMetadataDto;
 export type ResponseEnvelopeGroupDto =
     Components.Schemas.ResponseEnvelopeGroupDto;
+export type ResponseEnvelopeLeaderboardDto =
+    Components.Schemas.ResponseEnvelopeLeaderboardDto;
 export type ResponseEnvelopeListMatchDto =
     Components.Schemas.ResponseEnvelopeListMatchDto;
 export type ResponseEnvelopeListMatchOverviewDto =


### PR DESCRIPTION
- Added leaderboard controller
```
/groups/:groupId/leaderboard?scope=season&seasonId=foo

/groups/:groupId/leaderboard?scope=today

/groups/:groupId/leaderboard?scope=all-time

[
    {
        "id": "foo",
        "elo": 69,
        "totalPoints": 69,
        "totalGames": 69,
        "totalMoves": 69,
        "totalTeamSize": 69,
        "averagePointsPerMatch": 69,
        "averageTeamSize": 69,
        "rankBy": {
            "ELO": 1,
            "AVERAGE": 2
        }
    }
]
```
- Added season setting wakeTimeHour and dailyLeaderboard
- Added elo algorithm
- Added daily ranking selector: wake time (@Laurin-Notemann was für eine idee), midnight and 24 hours
- Added all time rankings  
- Added validation for season settings update
- Enforcing team sizes and exactly 1 finish move

closes #99 