### PR TITLE
Fixed all-time stats

### DIFF
--- a/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/LeaderboardEntryDto.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 @Data
 public class LeaderboardEntryDto {
-    private String playerId;
+    private PlayerDto playerDto;
     private int totalPoints = 0;
     private int totalGames = 0;
     private int totalMoves = 0;

--- a/mobile-app/api/generated/openapi.json
+++ b/mobile-app/api/generated/openapi.json
@@ -1602,7 +1602,7 @@
             "LeaderboardEntryDto": {
                 "type": "object",
                 "properties": {
-                    "playerId": { "type": "string" },
+                    "playerDto": { "$ref": "#/components/schemas/PlayerDto" },
                     "totalPoints": { "type": "integer", "format": "int32" },
                     "totalGames": { "type": "integer", "format": "int32" },
                     "totalMoves": { "type": "integer", "format": "int32" },

--- a/mobile-app/openapi/openapi.d.ts
+++ b/mobile-app/openapi/openapi.d.ts
@@ -36,7 +36,7 @@ declare namespace Components {
             entries?: LeaderboardEntryDto[];
         }
         export interface LeaderboardEntryDto {
-            playerId?: string;
+            playerDto?: PlayerDto;
             totalPoints?: number; // int32
             totalGames?: number; // int32
             totalMoves?: number; // int32


### PR DESCRIPTION
- The leaderboard endpoint now sends the player dto instead of the player id
- Stats are now calculated by profile instead of by player. Calculating by player results in a response containg mutliple player objects of the same profile.
- For all-time stats the backend sends the player of the active season if any is found. If the player is not in the active season, the latest found player is used 

closes #107 