### PR TITLE
Soft delete players

### DIFF
--- a/api/src/main/java/pro/beerpong/api/control/PlayerController.java
+++ b/api/src/main/java/pro/beerpong/api/control/PlayerController.java
@@ -22,8 +22,10 @@ public class PlayerController {
     }
 
     @GetMapping
-    public ResponseEntity<ResponseEnvelope<List<PlayerDto>>> getPlayers(@PathVariable String groupId, @PathVariable String seasonId) {
-        var players = playerService.getBySeasonId(seasonId);
+    public ResponseEntity<ResponseEnvelope<List<PlayerDto>>> getPlayers(@PathVariable String groupId,
+                                                                        @PathVariable String seasonId,
+                                                                        @RequestParam(required = false, defaultValue = "false") boolean showInactive) {
+        var players = playerService.getBySeasonId(seasonId, showInactive);
 
         if (players != null) {
             return ResponseEnvelope.ok(players);

--- a/api/src/main/java/pro/beerpong/api/control/ProfileController.java
+++ b/api/src/main/java/pro/beerpong/api/control/ProfileController.java
@@ -30,7 +30,7 @@ public class ProfileController {
         var group = groupService.getGroupById(groupId);
 
         if (group != null) {
-            var dto = profileService.createProfile(groupId, profileCreateDto);
+            var dto = profileService.createPlayer(groupId, profileCreateDto);
 
             subscriptionHandler.callEvent(new SocketEvent<>(SocketEventData.PROFILE_CREATE, groupId, dto));
 

--- a/api/src/main/java/pro/beerpong/api/model/dao/Player.java
+++ b/api/src/main/java/pro/beerpong/api/model/dao/Player.java
@@ -23,6 +23,9 @@ public class Player {
     @Transient
     private PlayerStatistics statistics;
 
+    @Column(nullable = false, columnDefinition = "boolean default true")
+    private boolean activeThisSeason;
+
     @OneToMany(mappedBy = "player")
     private List<TeamMember> teamMembers;
 }

--- a/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
@@ -24,6 +24,7 @@ public enum ErrorCodes {
     RULE_VALIDATION_FAILED("ruleValidationFailed", "The validation of the created rules has failed (invalid group or season id)"),
     PLAYER_VALIDATION_FAILED("playerValidationFailed", "The player is not part of the provided season or group!"),
     PLAYER_NOT_FOUND("playerNotFound", "The requested player could not be found!"),
+    PLAYER_ALREADY_DELETED("playerAlreadyDeleted", "This player has been deleted!"),
     PROFILE_NOT_FOUND("profileNotFound", "The requested profile could not be found!"),
     ASSET_NOT_FOUND("assetNotFound", "The requested asset could not be found!"),
     LEADERBOARD_SCOPE_NOT_FOUND("leaderboardScopeNotFound", "The leaderboard scope has to be one of: all-time, today, season"),

--- a/api/src/main/java/pro/beerpong/api/model/dto/PlayerDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/PlayerDto.java
@@ -7,5 +7,6 @@ public class PlayerDto {
     private String id;
     private ProfileDto profile;
     private SeasonDto season;
+    private boolean activeThisSeason;
     private PlayerStatisticsDto statistics;
 }

--- a/api/src/main/java/pro/beerpong/api/model/dto/ProfileCreatedDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/ProfileCreatedDto.java
@@ -1,0 +1,23 @@
+package pro.beerpong.api.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.lang.Nullable;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class ProfileCreatedDto extends ProfileDto {
+    private boolean reactivated;
+    @Nullable
+    private String lastActiveSeasonId;
+
+    public ProfileCreatedDto(ProfileDto profile, boolean reactivated, @Nullable String lastActiveSeasonId) {
+        setId(profile.getId());
+        setName(profile.getName());
+        setAvatarAsset(profile.getAvatarAsset());
+        setGroupId(profile.getGroupId());
+        this.reactivated = reactivated;
+        this.lastActiveSeasonId = lastActiveSeasonId;
+    }
+}

--- a/api/src/main/java/pro/beerpong/api/repository/PlayerRepository.java
+++ b/api/src/main/java/pro/beerpong/api/repository/PlayerRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 public interface PlayerRepository extends JpaRepository<Player, String> {
     List<Player> findAllBySeasonId(String seasonId);
 
+    List<Player> findAllByProfileId(String profileId);
+
     @Query("""
            SELECT new pro.beerpong.api.model.dao.PlayerStatistics(
                       COALESCE((SELECT COUNT(*)

--- a/api/src/main/java/pro/beerpong/api/repository/ProfileRepository.java
+++ b/api/src/main/java/pro/beerpong/api/repository/ProfileRepository.java
@@ -4,7 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import pro.beerpong.api.model.dao.Profile;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProfileRepository extends JpaRepository<Profile, String> {
     List<Profile> findAllByGroupId(String groupId);
+
+    Optional<Profile> findByName(String name);
 }

--- a/api/src/main/java/pro/beerpong/api/service/MatchService.java
+++ b/api/src/main/java/pro/beerpong/api/service/MatchService.java
@@ -184,6 +184,7 @@ public class MatchService {
 
     public Stream<PlayerDto> streamAllPlayersInSeason(String seasonId) {
         return playerRepository.findAllBySeasonId(seasonId).stream()
+                .filter(Player::isActiveThisSeason)
                 .map(playerMapper::playerToPlayerDto);
     }
 

--- a/api/src/main/java/pro/beerpong/api/service/PlayerService.java
+++ b/api/src/main/java/pro/beerpong/api/service/PlayerService.java
@@ -17,6 +17,7 @@ import pro.beerpong.api.sockets.SocketEvent;
 import pro.beerpong.api.sockets.SocketEventData;
 import pro.beerpong.api.sockets.SubscriptionHandler;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -41,6 +42,14 @@ public class PlayerService {
                 .toList();
     }
 
+    public Player findLatestPlayer(String profileId) {
+        return playerRepository.findAllByProfileId(profileId)
+                .stream()
+                .sorted(Comparator.comparing(player -> player.getSeason().getStartDate()))
+                .toList()
+                .getLast();
+    }
+
     public PlayerDto createPlayer(String seasonId, String profileId, PlayerCreateDto dto) {
         return seasonRepository.findById(seasonId)
                 .map(season -> this.createPlayer(season, profileId, dto))
@@ -51,7 +60,7 @@ public class PlayerService {
         var optional = profileRepository.findById(profileId);
 
         if (optional.isEmpty()) {
-            return null;
+            //create profile
         }
 
         var profile = optional.get();
@@ -66,6 +75,18 @@ public class PlayerService {
         subscriptionHandler.callEvent(new SocketEvent<>(SocketEventData.PLAYER_CREATE, season.getGroupId(), enrichedDto));
 
         return enrichedDto;
+    }
+
+    public boolean reactivatePlayer(PlayerDto dto) {
+        if (dto.isActiveThisSeason()) {
+            return false;
+        }
+
+        dto.setActiveThisSeason(true);
+
+        playerRepository.save(playerMapper.playerDtoToPlayer(dto));
+
+        return true;
     }
 
     public ErrorCodes deletePlayer(String id, String seasonId, String groupId) {

--- a/api/src/main/java/pro/beerpong/api/service/PlayerService.java
+++ b/api/src/main/java/pro/beerpong/api/service/PlayerService.java
@@ -3,6 +3,7 @@ package pro.beerpong.api.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import pro.beerpong.api.mapping.PlayerMapper;
+import pro.beerpong.api.model.dao.Group;
 import pro.beerpong.api.model.dao.Player;
 import pro.beerpong.api.model.dao.Profile;
 import pro.beerpong.api.model.dao.Season;
@@ -29,9 +30,13 @@ public class PlayerService {
     private final PlayerMapper playerMapper;
 
     public List<PlayerDto> getBySeasonId(String seasonId) {
+        return this.getBySeasonId(seasonId, false);
+    }
+
+    public List<PlayerDto> getBySeasonId(String seasonId, boolean showInactive) {
         return playerRepository.findAllBySeasonId(seasonId)
                 .stream()
-                .filter(Player::isActiveThisSeason)
+                .filter(player -> showInactive || player.isActiveThisSeason())
                 .map(this::createStatisticsEnrichedDto)
                 .toList();
     }

--- a/api/src/main/java/pro/beerpong/api/service/PlayerService.java
+++ b/api/src/main/java/pro/beerpong/api/service/PlayerService.java
@@ -31,6 +31,7 @@ public class PlayerService {
     public List<PlayerDto> getBySeasonId(String seasonId) {
         return playerRepository.findAllBySeasonId(seasonId)
                 .stream()
+                .filter(Player::isActiveThisSeason)
                 .map(this::createStatisticsEnrichedDto)
                 .toList();
     }
@@ -53,6 +54,7 @@ public class PlayerService {
 
         player.setSeason(season);
         player.setProfile(profile);
+        player.setActiveThisSeason(true);
 
         var enrichedDto = createStatisticsEnrichedDto(playerRepository.save(player));
 
@@ -66,6 +68,11 @@ public class PlayerService {
 
         playerRepository.findById(id).ifPresentOrElse(player -> {
             var season = seasonRepository.findById(seasonId).orElse(null);
+
+            if (!player.isActiveThisSeason()) {
+                error.set(ErrorCodes.PLAYER_ALREADY_DELETED);
+                return;
+            }
 
             if (season == null) {
                 error.set(ErrorCodes.SEASON_NOT_FOUND);
@@ -81,7 +88,8 @@ public class PlayerService {
                 if (player.getSeason().getId().equals(seasonId) && player.getSeason().getGroupId().equals(groupId)) {
                     subscriptionHandler.callEvent(new SocketEvent<>(SocketEventData.PLAYER_DELETE, groupId, createStatisticsEnrichedDto(player)));
 
-                    playerRepository.deleteById(id);
+                    player.setActiveThisSeason(false);
+                    playerRepository.save(player);
                 } else {
                     error.set(ErrorCodes.PLAYER_VALIDATION_FAILED);
                 }
@@ -111,6 +119,7 @@ public class PlayerService {
         Player player = new Player();
         player.setProfile(profile);
         player.setSeason(season);
+        player.setActiveThisSeason(true);
         return playerMapper.playerToPlayerDto(playerRepository.save(player));
     }
 

--- a/api/src/main/java/pro/beerpong/api/service/ProfileService.java
+++ b/api/src/main/java/pro/beerpong/api/service/ProfileService.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Service;
 import pro.beerpong.api.mapping.GroupMapper;
 import pro.beerpong.api.mapping.ProfileMapper;
 import pro.beerpong.api.model.dao.Profile;
+import pro.beerpong.api.model.dao.Season;
 import pro.beerpong.api.model.dto.ProfileCreateDto;
+import pro.beerpong.api.model.dto.ProfileCreatedDto;
 import pro.beerpong.api.model.dto.ProfileDto;
 import pro.beerpong.api.repository.GroupRepository;
 import pro.beerpong.api.repository.ProfileRepository;
@@ -24,7 +26,48 @@ public class ProfileService {
     private final ProfileMapper profileMapper;
     private final PlayerService playerService;
 
+    public ProfileCreatedDto createPlayer(String groupId, ProfileCreateDto dto) {
+        var existing = this.getProfileByName(groupId, dto.getName());
+
+        if (existing != null) {
+            var groupOptional = groupRepository.findById(groupId);
+
+            if (groupOptional.isEmpty() || !existing.getGroupId().equals(groupId)) {
+                return null;
+            }
+
+            var group = groupOptional.get();
+            var season = group.getActiveSeason();
+
+            if (season == null) {
+                return null;
+            }
+
+            var existingPlayer = playerService.getBySeasonId(season.getId(), true).stream()
+                    .filter(playerDto -> playerDto.getProfile().getId().equals(existing.getId()))
+                    .findFirst();
+
+            if (existingPlayer.isPresent()) {
+                boolean success = playerService.reactivatePlayer(existingPlayer.get());
+
+                return new ProfileCreatedDto(existing, success, (success ? season.getId() : null));
+            } else {
+                var lastPlayer = playerService.findLatestPlayer(existing.getId());
+
+                playerService.createPlayer(season, profileMapper.profileDtoToProfile(existing));
+
+                return new ProfileCreatedDto(existing, false, (lastPlayer != null ? lastPlayer.getSeason().getId() : null));
+            }
+        } else {
+            return new ProfileCreatedDto(this.createProfile(groupId, dto), false, null);
+        }
+    }
+
     public ProfileDto createProfile(String groupId, ProfileCreateDto profileCreateDto) {
+        return this.createProfile(groupId, profileCreateDto, true);
+    }
+
+    public ProfileDto createProfile(String groupId, ProfileCreateDto profileCreateDto, boolean createPlayer) {
         var groupOptional = groupRepository.findById(groupId);
 
         var profile = profileMapper.profileCreateDtoToProfile(profileCreateDto);
@@ -32,7 +75,9 @@ public class ProfileService {
 
         var savedProfile = profileRepository.save(profile);
 
-        playerService.createPlayer(savedProfile.getGroup().getActiveSeason(), savedProfile);
+        if (createPlayer) {
+            playerService.createPlayer(savedProfile.getGroup().getActiveSeason(), savedProfile);
+        }
 
         return profileMapper.profileToProfileDto(savedProfile);
     }
@@ -59,6 +104,13 @@ public class ProfileService {
 
     public Profile getRawProfileById(String id) {
         return profileRepository.findById(id).orElse(null);
+    }
+
+    public ProfileDto getProfileByName(String groupId, String name) {
+        return listAllProfilesOfGroup(groupId).stream()
+                .filter(profileDto -> profileDto.getName().equals(name))
+                .findFirst()
+                .orElse(null);
     }
 
     public boolean deleteProfile(String id) {

--- a/mobile-app/api/generated/openapi.json
+++ b/mobile-app/api/generated/openapi.json
@@ -917,6 +917,12 @@
                         "in": "path",
                         "required": true,
                         "schema": { "type": "string" }
+                    },
+                    {
+                        "name": "showInactive",
+                        "in": "query",
+                        "required": false,
+                        "schema": { "type": "boolean", "default": false }
                     }
                 ],
                 "responses": {
@@ -1480,6 +1486,7 @@
                     "id": { "type": "string" },
                     "profile": { "$ref": "#/components/schemas/ProfileDto" },
                     "season": { "$ref": "#/components/schemas/SeasonDto" },
+                    "activeThisSeason": { "type": "boolean" },
                     "statistics": {
                         "$ref": "#/components/schemas/PlayerStatisticsDto"
                     }

--- a/mobile-app/openapi/openapi.d.ts
+++ b/mobile-app/openapi/openapi.d.ts
@@ -89,6 +89,7 @@ declare namespace Components {
             id?: string;
             profile?: ProfileDto;
             season?: SeasonDto;
+            activeThisSeason?: boolean;
             statistics?: PlayerStatisticsDto;
         }
         export interface PlayerStatisticsDto {
@@ -523,10 +524,14 @@ declare namespace Paths {
         namespace Parameters {
             export type GroupId = string;
             export type SeasonId = string;
+            export type ShowInactive = boolean;
         }
         export interface PathParameters {
             groupId: Parameters.GroupId;
             seasonId: Parameters.SeasonId;
+        }
+        export interface QueryParameters {
+            showInactive?: Parameters.ShowInactive;
         }
         namespace Responses {
             export type $200 = Components.Schemas.ResponseEnvelopeListPlayerDto;
@@ -923,7 +928,9 @@ export interface OperationMethods {
      * getPlayers
      */
     'getPlayers'(
-        parameters?: Parameters<Paths.GetPlayers.PathParameters> | null,
+        parameters?: Parameters<
+            Paths.GetPlayers.QueryParameters & Paths.GetPlayers.PathParameters
+        > | null,
         data?: any,
         config?: AxiosRequestConfig
     ): OperationResponse<Paths.GetPlayers.Responses.$200>;
@@ -1224,7 +1231,10 @@ export interface PathsDictionary {
          * getPlayers
          */
         'get'(
-            parameters?: Parameters<Paths.GetPlayers.PathParameters> | null,
+            parameters?: Parameters<
+                Paths.GetPlayers.QueryParameters &
+                    Paths.GetPlayers.PathParameters
+            > | null,
             data?: any,
             config?: AxiosRequestConfig
         ): OperationResponse<Paths.GetPlayers.Responses.$200>;


### PR DESCRIPTION
Implements soft deletion of players in the backend and a new way to create players/profiles:

- The player dao now has a boolean 'activeThisSeason' which is true, when a player is normally playing this season or false, if the player has been deleted from the current season
- Players that have been deleted are not copied to new seasons
- Deleted players are not shown in GET: /players by default, but can be included using GET: /players?showInactive=true
- Deleted players are not included in the season or daily leaderboards, but are still shown in the all time leaderboard

- When a profile is created now the backend checks if a profile with the supplied name already exists. If yes, the backend checks if a player matching this profile id exists in the current season. If a player exists but has just been deleted, it gets reactivated. If no player exists, a new one is created but linked to the found profile.
- The response of POST /groups/{groupId}/profiles now contains a boolean reactivated which is true, when the player has been "undeleted" and a optional string lastActiveSeasonId which is null, unless the profile had active players in older seasons.

closes: #149 
closes: #152 