### PR TITLE
Rule moves are updated when a new season starts

### DIFF
--- a/api/README-Socket-Updates.md
+++ b/api/README-Socket-Updates.md
@@ -112,7 +112,6 @@ A list of all event types with their corresponding dto and all available scopes:
 
 * **ruleMovesCreate:** When a rule move is created
 * **ruleMovesUpdate:** When a rule move is update
-* **ruleMovesDelete:** When a rule move is delete
 
 #### Seasons (body: SeasonStartDto | SeasonDto)
 

--- a/api/src/main/java/pro/beerpong/api/control/RuleMoveController.java
+++ b/api/src/main/java/pro/beerpong/api/control/RuleMoveController.java
@@ -65,32 +65,6 @@ public class RuleMoveController {
         return ResponseEnvelope.ok(moveService.updateRuleMove(groupId, move, dto));
     }
 
-    @DeleteMapping("/{ruleMoveId}")
-    public ResponseEntity<ResponseEnvelope<String>> deleteRuleMove(@PathVariable String groupId, @PathVariable String seasonId, @PathVariable String ruleMoveId) {
-        var pair = seasonService.getSeasonAndGroup(groupId, seasonId);
-        var error = seasonService.validateActiveSeason(String.class, pair);
-
-        if (error != null) {
-            return error;
-        }
-
-        var move = moveService.getById(ruleMoveId);
-
-        if (move == null) {
-            return ResponseEnvelope.notOk(ErrorCodes.RULE_MOVE_NOT_FOUND);
-        }
-
-        if (moveService.validateGroupAndSeason(groupId, seasonId, move)) {
-            if (moveService.delete(groupId, move)) {
-                return ResponseEnvelope.ok("OK");
-            } else {
-                return ResponseEnvelope.notOk(ErrorCodes.RULE_MOVE_NOT_FOUND);
-            }
-        } else {
-            return ResponseEnvelope.notOk(ErrorCodes.RULE_MOVE_VALIDATION_FAILED);
-        }
-    }
-
     @GetMapping
     public ResponseEntity<ResponseEnvelope<List<RuleMoveDto>>> getAllRuleMoves(@PathVariable String groupId, @PathVariable String seasonId) {
         return ResponseEnvelope.ok(moveService.getAllMoves(seasonId));

--- a/api/src/main/java/pro/beerpong/api/control/RuleMoveController.java
+++ b/api/src/main/java/pro/beerpong/api/control/RuleMoveController.java
@@ -34,7 +34,7 @@ public class RuleMoveController {
             return error;
         }
 
-        var move = moveService.createRuleMove(pair.getFirst(), pair.getSecond(), dto);
+        var move = moveService.createRuleMove(pair.getFirst(), pair.getSecond(), dto, true);
 
         if (move != null) {
             return ResponseEnvelope.ok(move);

--- a/api/src/main/java/pro/beerpong/api/control/SeasonController.java
+++ b/api/src/main/java/pro/beerpong/api/control/SeasonController.java
@@ -29,6 +29,10 @@ public class SeasonController {
             return ResponseEnvelope.notOk(ErrorCodes.INVALID_SEASON_NAME);
         }
 
+        if (dto.invalidRuleMoves()) {
+            return ResponseEnvelope.notOk(ErrorCodes.INVALID_RULE_MOVES);
+        }
+
         var season = seasonService.startNewSeason(dto, groupId);
 
         if (season != null) {

--- a/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
@@ -24,6 +24,7 @@ public enum ErrorCodes {
     SEASON_NOT_OF_GROUP(HttpStatus.FORBIDDEN, "seasonHasDifferentGroup", "The season does not match the provided group id!"),
     SEASON_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "seasonValidationFailed", "The validation of the created season has failed (invalid group id)"),
     INVALID_SEASON_NAME(HttpStatus.BAD_REQUEST, "invalidSeasonName", "Season name must be non-null, non-empty and between 2 and 50 characters!"),
+    INVALID_RULE_MOVES(HttpStatus.BAD_REQUEST, "invalidRuleMoves", "Rule Moves must be non-null, contain at least one normal and one finish move and every move must be valid (name non-null, non empty; pointsForScorer and pointsForTeam > 0)"),
     INVALID_SEASON_ID(HttpStatus.BAD_REQUEST, "invalidSeasonId", "Season id must be non-null and non-empty!"),
     INVALID_SEASON_DTO(HttpStatus.BAD_REQUEST, "invalidSeasonDto", "Season update dto must be non-null and have non-null seasonSettings!"),
     /* MATCHES */

--- a/api/src/main/java/pro/beerpong/api/model/dto/RuleMoveCreateDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/RuleMoveCreateDto.java
@@ -8,4 +8,9 @@ public class RuleMoveCreateDto {
     private int pointsForTeam;
     private int pointsForScorer;
     private boolean finishingMove;
+
+    public boolean invalidDto() {
+        return this.name == null || this.name.isEmpty() ||
+                this.pointsForTeam < 0 || this.pointsForScorer < 0;
+    }
 }

--- a/api/src/main/java/pro/beerpong/api/model/dto/SeasonCreateDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/SeasonCreateDto.java
@@ -2,16 +2,28 @@ package pro.beerpong.api.model.dto;
 
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class SeasonCreateDto {
     public static final int SEASON_NAME_MIN_LENGTH = 2;
     public static final int SEASON_NAME_MAX_LENGTH = 50;
 
     private String oldSeasonName;
+    private List<RuleMoveCreateDto> ruleMoves;
 
     public boolean invalidName() {
         return this.oldSeasonName == null || this.oldSeasonName.isEmpty() ||
                 this.oldSeasonName.length() < SEASON_NAME_MIN_LENGTH ||
                 this.oldSeasonName.length() > SEASON_NAME_MAX_LENGTH;
+    }
+
+    public boolean invalidRuleMoves() {
+        return this.ruleMoves == null ||
+                this.ruleMoves.stream().noneMatch(RuleMoveCreateDto::isFinishingMove) ||
+                this.ruleMoves.stream()
+                        .filter(RuleMoveCreateDto::isFinishingMove)
+                        .count() == this.ruleMoves.size() ||
+                this.ruleMoves.stream().anyMatch(RuleMoveCreateDto::invalidDto);
     }
 }

--- a/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
+++ b/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
@@ -68,7 +68,6 @@ public class RuleMoveService {
         move.setName(createDto.getName());
         move.setPointsForTeam(createDto.getPointsForTeam());
         move.setPointsForScorer(createDto.getPointsForScorer());
-        move.setFinishingMove(createDto.isFinishingMove());
 
         var dto = moveMapper.ruleMoveToRuleMoveDto(moveRepository.save(moveMapper.ruleMoveDtoToRuleMove(move)));
 

--- a/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
+++ b/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
@@ -16,7 +16,6 @@ import pro.beerpong.api.sockets.SocketEventData;
 import pro.beerpong.api.sockets.SubscriptionHandler;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class RuleMoveService {
@@ -45,17 +44,20 @@ public class RuleMoveService {
         this.moveMapper = moveMapper;
     }
 
-    public RuleMoveDto createRuleMove(Group group, Season season, RuleMoveCreateDto createDto) {
+    public RuleMoveDto createRuleMove(Group group, Season season, RuleMoveCreateDto createDto, boolean callSocket) {
         var rule = moveMapper.ruleMoveCreateDtoToRuleMove(createDto);
         rule.setSeason(season);
 
-        if (!rule.getSeason().getId().equals(season.getId()) || !rule.getSeason().getGroupId().equals(group.getId())) {
+        if (!rule.getSeason().getId().equals(season.getId()) || !rule.getSeason().getGroupId().equals(group.getId()) ||
+                createDto.invalidDto()) {
             return null;
         }
 
         var dto = moveMapper.ruleMoveToRuleMoveDto(moveRepository.save(rule));
 
-        subscriptionHandler.callEvent(new SocketEvent<>(SocketEventData.RULE_MOVE_CREATE, group.getId(), dto));
+        if (callSocket) {
+            subscriptionHandler.callEvent(new SocketEvent<>(SocketEventData.RULE_MOVE_CREATE, group.getId(), dto));
+        }
 
         return dto;
     }
@@ -74,19 +76,6 @@ public class RuleMoveService {
         subscriptionHandler.callEvent(new SocketEvent<>(SocketEventData.RULE_MOVE_UPDATE, groupId, dto));
 
         return dto;
-    }
-
-    public boolean delete(String groupId, RuleMoveDto dto) {
-        return Optional.ofNullable(dto)
-                .map(ruleMove -> {
-                    moveRepository.deleteById(ruleMove.getId());
-
-                    subscriptionHandler.callEvent(new SocketEvent<>(SocketEventData.RULE_MOVE_DELETE, groupId, ruleMove));
-
-                    return true;
-                })
-                .orElse(false);
-
     }
 
     public Pair<Integer, Integer> getPointsById(String ruleMoveId) {

--- a/api/src/main/java/pro/beerpong/api/service/SeasonService.java
+++ b/api/src/main/java/pro/beerpong/api/service/SeasonService.java
@@ -81,8 +81,10 @@ public class SeasonService {
 
             playerService.copyPlayersFromOldSeason(oldSeason, season);
             ruleService.copyRulesFromOldSeason(oldSeason, season);
-            ruleMoveService.copyRuleMovesFromOldSeason(oldSeason, season);
         }
+
+        var finalSeason = season;
+        dto.getRuleMoves().forEach(ruleMoveDto -> ruleMoveService.createRuleMove(group, finalSeason, ruleMoveDto, false));
 
         group.setActiveSeason(season);
         groupRepository.save(group);

--- a/api/src/main/java/pro/beerpong/api/sockets/SocketEventData.java
+++ b/api/src/main/java/pro/beerpong/api/sockets/SocketEventData.java
@@ -23,7 +23,6 @@ public class SocketEventData<T> {
 
     public static final SocketEventData<RuleMoveDto> RULE_MOVE_CREATE = new SocketEventData<>(RuleMoveDto.class, SocketEventType.RULE_MOVES, "ruleMovesCreate");
     public static final SocketEventData<RuleMoveDto> RULE_MOVE_UPDATE = new SocketEventData<>(RuleMoveDto.class, SocketEventType.RULE_MOVES, "ruleMovesUpdate");
-    public static final SocketEventData<RuleMoveDto> RULE_MOVE_DELETE = new SocketEventData<>(RuleMoveDto.class, SocketEventType.RULE_MOVES, "ruleMovesDelete");
 
     public static final SocketEventData<SeasonStartDto> SEASON_START = new SocketEventData<>(SeasonStartDto.class, SocketEventType.SEASONS, "seasonStart");
     public static final SocketEventData<SeasonDto> SEASON_UPDATE = new SocketEventData<>(SeasonDto.class, SocketEventType.SEASONS, "seasonUpdate");

--- a/mobile-app/api/generated/openapi.json
+++ b/mobile-app/api/generated/openapi.json
@@ -223,42 +223,6 @@
                         }
                     }
                 }
-            },
-            "delete": {
-                "tags": ["rule-move-controller"],
-                "operationId": "deleteRuleMove",
-                "parameters": [
-                    {
-                        "name": "groupId",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string" }
-                    },
-                    {
-                        "name": "seasonId",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string" }
-                    },
-                    {
-                        "name": "ruleMoveId",
-                        "in": "path",
-                        "required": true,
-                        "schema": { "type": "string" }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ResponseEnvelopeString"
-                                }
-                            }
-                        }
-                    }
-                }
             }
         },
         "/groups/{groupId}/seasons/{seasonId}/matches/{id}": {
@@ -1445,7 +1409,15 @@
             },
             "SeasonCreateDto": {
                 "type": "object",
-                "properties": { "oldSeasonName": { "type": "string" } }
+                "properties": {
+                    "oldSeasonName": { "type": "string" },
+                    "ruleMoves": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RuleMoveCreateDto"
+                        }
+                    }
+                }
             },
             "ResponseEnvelopeString": {
                 "type": "object",

--- a/mobile-app/openapi/openapi.d.ts
+++ b/mobile-app/openapi/openapi.d.ts
@@ -235,6 +235,7 @@ declare namespace Components {
         }
         export interface SeasonCreateDto {
             oldSeasonName?: string;
+            ruleMoves?: RuleMoveCreateDto[];
         }
         export interface SeasonDto {
             id?: string;
@@ -349,21 +350,6 @@ declare namespace Paths {
             groupId: Parameters.GroupId;
             seasonId: Parameters.SeasonId;
             id: Parameters.Id;
-        }
-        namespace Responses {
-            export type $200 = Components.Schemas.ResponseEnvelopeString;
-        }
-    }
-    namespace DeleteRuleMove {
-        namespace Parameters {
-            export type GroupId = string;
-            export type RuleMoveId = string;
-            export type SeasonId = string;
-        }
-        export interface PathParameters {
-            groupId: Parameters.GroupId;
-            seasonId: Parameters.SeasonId;
-            ruleMoveId: Parameters.RuleMoveId;
         }
         namespace Responses {
             export type $200 = Components.Schemas.ResponseEnvelopeString;
@@ -765,14 +751,6 @@ export interface OperationMethods {
         config?: AxiosRequestConfig
     ): OperationResponse<Paths.UpdateRuleMove.Responses.$200>;
     /**
-     * deleteRuleMove
-     */
-    'deleteRuleMove'(
-        parameters?: Parameters<Paths.DeleteRuleMove.PathParameters> | null,
-        data?: any,
-        config?: AxiosRequestConfig
-    ): OperationResponse<Paths.DeleteRuleMove.Responses.$200>;
-    /**
      * getMatchById
      */
     'getMatchById'(
@@ -1043,14 +1021,6 @@ export interface PathsDictionary {
             data?: Paths.UpdateRuleMove.RequestBody,
             config?: AxiosRequestConfig
         ): OperationResponse<Paths.UpdateRuleMove.Responses.$200>;
-        /**
-         * deleteRuleMove
-         */
-        'delete'(
-            parameters?: Parameters<Paths.DeleteRuleMove.PathParameters> | null,
-            data?: any,
-            config?: AxiosRequestConfig
-        ): OperationResponse<Paths.DeleteRuleMove.Responses.$200>;
     };
     ['/groups/{groupId}/seasons/{seasonId}/matches/{id}']: {
         /**


### PR DESCRIPTION
- removed DEL rule-moves
- PUT rule-moves ignores changes to isFinish
- PUT active-season now needs a list of ruleMoves for the new season:
"ruleMoves": [
  {
    "name": "Normal",
    "pointsForTeam": 0,
    "pointsForScorer": 1,
    "finishingMove": true
  }
...
]
the list must be non-null and contain at least one finish and one none-finish move

closes #189