### PR TITLE
Feat/different games

### DIFF
--- a/.github/workflows/generate-openapi.yaml
+++ b/.github/workflows/generate-openapi.yaml
@@ -53,11 +53,11 @@ jobs:
             # For direct pushes or workflow_dispatch, check last few commits
             COMMIT_RANGE="HEAD~10..HEAD"
           fi
-          
+
           COMMIT_MESSAGES=$(git log $COMMIT_RANGE --format='%s')
           echo "Commit messages in range:"
           echo "$COMMIT_MESSAGES"
-          
+
           if echo "$COMMIT_MESSAGES" | grep -q "chore: update openapi types"; then
             echo "has_bot_author=true" >> $GITHUB_OUTPUT
             echo "A recent commit contains the version bump message. Stopping the workflow."
@@ -91,8 +91,8 @@ jobs:
           POSTGRES_URL: jdbc:postgresql://localhost:5432/beerpong
           API_BASE_URL: http://localhost:8080/
         working-directory: api
-        
-      - run: sed -i 's#"\*/\*"#"application/json"#g' ./mobile-app/api/generated/openapi.json
+
+      - run: sed -i 's/"\*\\\?\/\*"/"application\/json"/g' ./mobile-app/api/generated/openapi.json
         if: steps.check_authors.outputs.has_bot_author != 'true'
 
       - name: Cache npm packages
@@ -115,7 +115,7 @@ jobs:
       - run: npm ci && npm run gen-types && npm run format
         if: steps.check_authors.outputs.has_bot_author != 'true'
         working-directory: mobile-app
-        
+
       - uses: stefanzweifel/git-auto-commit-action@v5
         if: steps.check_authors.outputs.has_bot_author != 'true'
         with:

--- a/.github/workflows/generate-openapi.yaml
+++ b/.github/workflows/generate-openapi.yaml
@@ -94,7 +94,7 @@ jobs:
 
       - run: cat mobile-app/api/generated/openapi.json
 
-      - run: sed -i '' 's#"\*/\*"#"application/json"#g' ./mobile-app/api/generated/openapi.json
+      - run: sed -i 's#"\*/\*"#"application/json"#g' ./mobile-app/api/generated/openapi.json
         if: steps.check_authors.outputs.has_bot_author != 'true'
 
       - run: cat mobile-app/api/generated/openapi.json

--- a/.github/workflows/generate-openapi.yaml
+++ b/.github/workflows/generate-openapi.yaml
@@ -97,6 +97,8 @@ jobs:
       - run: sed -i '' 's#"\*/\*"#"application/json"#g' ./mobile-app/api/generated/openapi.json
         if: steps.check_authors.outputs.has_bot_author != 'true'
 
+      - run: cat mobile-app/api/generated/openapi.json
+
       - name: Cache npm packages
         if: steps.check_authors.outputs.has_bot_author != 'true'
         uses: actions/cache@v4

--- a/.github/workflows/generate-openapi.yaml
+++ b/.github/workflows/generate-openapi.yaml
@@ -92,12 +92,8 @@ jobs:
           API_BASE_URL: http://localhost:8080/
         working-directory: api
 
-      - run: cat mobile-app/api/generated/openapi.json
-
       - run: sed -i 's#"\*/\*"#"application/json"#g' ./mobile-app/api/generated/openapi.json
         if: steps.check_authors.outputs.has_bot_author != 'true'
-
-      - run: cat mobile-app/api/generated/openapi.json
 
       - name: Cache npm packages
         if: steps.check_authors.outputs.has_bot_author != 'true'

--- a/.github/workflows/generate-openapi.yaml
+++ b/.github/workflows/generate-openapi.yaml
@@ -92,7 +92,9 @@ jobs:
           API_BASE_URL: http://localhost:8080/
         working-directory: api
 
-      - run: sed -i 's/"\*\\\?\/\*"/"application\/json"/g' ./mobile-app/api/generated/openapi.json
+      - run: cat mobile-app/api/generated/openapi.json
+
+      - run: sed -i '' 's#"\*/\*"#"application/json"#g' ./mobile-app/api/generated/openapi.json
         if: steps.check_authors.outputs.has_bot_author != 'true'
 
       - name: Cache npm packages

--- a/api/src/main/java/pro/beerpong/api/control/GroupController.java
+++ b/api/src/main/java/pro/beerpong/api/control/GroupController.java
@@ -30,7 +30,13 @@ public class GroupController {
             return ResponseEnvelope.notOk(ErrorCodes.INVALID_GROUP_PROFILE_NAMES);
         }
 
-        return ResponseEnvelope.ok(groupService.createGroup(groupCreateDto));
+        var group = groupService.createGroup(groupCreateDto);
+
+        if (group == null) {
+            return ResponseEnvelope.notOk(ErrorCodes.INVALID_GROUP_SPORT);
+        }
+
+        return ResponseEnvelope.ok(group);
     }
 
     @GetMapping

--- a/api/src/main/java/pro/beerpong/api/control/GroupPresetsController.java
+++ b/api/src/main/java/pro/beerpong/api/control/GroupPresetsController.java
@@ -24,13 +24,8 @@ public class GroupPresetsController {
     public static final GroupPreset CHESS = new GroupPreset("chess", "Chess", "https://media.istockphoto.com/id/1128789429/photo/plan-leading-strategy-of-successful-business-competition-leader-concept-hand-of-player-chess.jpg?s=612x612&w=0&k=20&c=srlCT0xWXduYvZsQgGVYl6B4QAaBjoPjpsceTQrP5XQ=");
     public static final GroupPreset BILLIARDS = new GroupPreset("billiards", "Billiards", "https://media.istockphoto.com/id/1370682737/photo/a-group-of-young-people-came-to-play-billiards-and-in-the-young-hands-was-a-cane-and-layers.jpg?s=612x612&w=0&k=20&c=monjVEGbEEjeau83cCqBScfiR1n9SOaqlZpDEB3-Ioo=");
 
-    public static final GroupPreset[] PRESETS = new GroupPreset[]{
-            BEERPONG,
-            KICKER,
-            TABLE_TENNIS,
-            CHESS,
-            BILLIARDS
-    };
+public static final List<GroupPreset> PRESETS =
+    List.of(BEERPONG, KICKER, TABLE_TENNIS, CHESS, BILLIARDS);
 
     public static Optional<GroupPreset> byId(@Nullable String id) {
         if (id == null) return Optional.empty();

--- a/api/src/main/java/pro/beerpong/api/control/GroupPresetsController.java
+++ b/api/src/main/java/pro/beerpong/api/control/GroupPresetsController.java
@@ -2,12 +2,16 @@ package pro.beerpong.api.control;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import pro.beerpong.api.model.dto.AssetMetadataDto;
 import pro.beerpong.api.model.dto.GroupPreset;
 import pro.beerpong.api.model.dto.ResponseEnvelope;
+
+import java.util.Arrays;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/group-presets")
@@ -26,6 +30,12 @@ public class GroupPresetsController {
             CHESS,
             BILLIARDS
     };
+
+    public static Optional<GroupPreset> byId(@Nullable String id) {
+        if (id == null) return Optional.empty();
+
+        return Arrays.stream(PRESETS).filter(groupPreset -> groupPreset.getId().equals(id)).findFirst();
+    }
 
     @GetMapping
     public ResponseEntity<ResponseEnvelope<GroupPreset[]>> getPresets() {

--- a/api/src/main/java/pro/beerpong/api/control/GroupPresetsController.java
+++ b/api/src/main/java/pro/beerpong/api/control/GroupPresetsController.java
@@ -1,0 +1,34 @@
+package pro.beerpong.api.control;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pro.beerpong.api.model.dto.AssetMetadataDto;
+import pro.beerpong.api.model.dto.GroupPreset;
+import pro.beerpong.api.model.dto.ResponseEnvelope;
+
+@RestController
+@RequestMapping("/group-presets")
+@RequiredArgsConstructor
+public class GroupPresetsController {
+    public static final GroupPreset BEERPONG = new GroupPreset("beerpong", "Beerpong", "https://www.shutterstock.com/image-photo/cups-plastic-ball-beer-pong-600nw-1107685832.jpg");
+    public static final GroupPreset KICKER = new GroupPreset("kicker", "Kicker", "https://media.istockphoto.com/id/696594232/photo/foosball-at-modern-office-close-up-view.jpg?s=612x612&w=0&k=20&c=skF0hp5i_9ctZ2MmkqLdaOklvwSGbqEqcAu0JLF8M5c=");
+    public static final GroupPreset TABLE_TENNIS = new GroupPreset("tabletennis", "Table Tennis", "https://media.istockphoto.com/id/1425158165/photo/table-tennis-ping-pong-paddles-and-white-ball-on-blue-board.jpg?s=612x612&w=0&k=20&c=KSdi4bEGoxdhaGMnl6CZaqTLbKbobArgrrpLem3oN98=");
+    public static final GroupPreset CHESS = new GroupPreset("chess", "Chess", "https://media.istockphoto.com/id/1128789429/photo/plan-leading-strategy-of-successful-business-competition-leader-concept-hand-of-player-chess.jpg?s=612x612&w=0&k=20&c=srlCT0xWXduYvZsQgGVYl6B4QAaBjoPjpsceTQrP5XQ=");
+    public static final GroupPreset BILLIARDS = new GroupPreset("billiards", "Billiards", "https://media.istockphoto.com/id/1370682737/photo/a-group-of-young-people-came-to-play-billiards-and-in-the-young-hands-was-a-cane-and-layers.jpg?s=612x612&w=0&k=20&c=monjVEGbEEjeau83cCqBScfiR1n9SOaqlZpDEB3-Ioo=");
+
+    public static final GroupPreset[] PRESETS = new GroupPreset[]{
+            BEERPONG,
+            KICKER,
+            TABLE_TENNIS,
+            CHESS,
+            BILLIARDS
+    };
+
+    @GetMapping
+    public ResponseEntity<ResponseEnvelope<GroupPreset[]>> getPresets() {
+        return ResponseEnvelope.ok(PRESETS);
+    }
+}

--- a/api/src/main/java/pro/beerpong/api/control/GroupPresetsController.java
+++ b/api/src/main/java/pro/beerpong/api/control/GroupPresetsController.java
@@ -29,8 +29,9 @@ public static final List<GroupPreset> PRESETS =
 
     public static Optional<GroupPreset> byId(@Nullable String id) {
         if (id == null) return Optional.empty();
-
-        return Arrays.stream(PRESETS).filter(groupPreset -> groupPreset.getId().equals(id)).findFirst();
+        return PRESETS.stream()
+                    .filter(p -> p.getId().equals(id))
+                    .findFirst();
     }
 
     @GetMapping

--- a/api/src/main/java/pro/beerpong/api/control/GroupPresetsController.java
+++ b/api/src/main/java/pro/beerpong/api/control/GroupPresetsController.java
@@ -12,6 +12,7 @@ import pro.beerpong.api.model.dto.ResponseEnvelope;
 
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.List;
 
 @RestController
 @RequestMapping("/group-presets")
@@ -38,7 +39,7 @@ public class GroupPresetsController {
     }
 
     @GetMapping
-    public ResponseEntity<ResponseEnvelope<GroupPreset[]>> getPresets() {
+    public ResponseEntity<ResponseEnvelope<List<GroupPreset>>> getPresets() {
         return ResponseEnvelope.ok(PRESETS);
     }
 }

--- a/api/src/main/java/pro/beerpong/api/mapping/GroupMapper.java
+++ b/api/src/main/java/pro/beerpong/api/mapping/GroupMapper.java
@@ -1,13 +1,33 @@
 package pro.beerpong.api.mapping;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.web.util.UriComponentsBuilder;
+import pro.beerpong.api.control.GroupPresetsController;
+import pro.beerpong.api.model.dao.Asset;
 import pro.beerpong.api.model.dao.Group;
 import pro.beerpong.api.model.dto.GroupCreateDto;
 import pro.beerpong.api.model.dto.GroupDto;
+import pro.beerpong.api.model.dto.GroupPreset;
 
 @Mapper(componentModel = "spring", uses = AssetMapper.class)
-public interface GroupMapper {
-    Group groupDtoToGroup(GroupDto groupDto);
-    Group groupCreateDtoToGroup(GroupCreateDto groupDto);
-    GroupDto groupToGroupDto(Group groupDto);
+public abstract class GroupMapper {
+    @Mapping(target = "sportPreset", expression = "java(fromPreset(groupDto))")
+    public abstract Group groupDtoToGroup(GroupDto groupDto);
+    @Mapping(target = "sportPreset", expression = "java(fromDto(groupDto))")
+    public abstract Group groupCreateDtoToGroup(GroupCreateDto groupDto);
+    @Mapping(target = "sportPreset", expression = "java(groupPreset(group))")
+    public abstract GroupDto groupToGroupDto(Group group);
+
+    protected String fromDto(GroupCreateDto groupDto) {
+        return GroupPresetsController.byId(groupDto.getSportPreset()).isPresent() ? groupDto.getSportPreset() : null;
+    }
+
+    protected String fromPreset(GroupDto groupDto) {
+        return (groupDto.getSportPreset() == null ? null : groupDto.getSportPreset().getId());
+    }
+
+    protected GroupPreset groupPreset(Group group) {
+        return GroupPresetsController.byId(group.getSportPreset()).orElse(null);
+    }
 }

--- a/api/src/main/java/pro/beerpong/api/model/dao/Group.java
+++ b/api/src/main/java/pro/beerpong/api/model/dao/Group.java
@@ -2,6 +2,7 @@ package pro.beerpong.api.model.dao;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import pro.beerpong.api.model.dto.GroupPreset;
 
 @Entity(name = "groups")
 @Data
@@ -18,4 +19,6 @@ public class Group {
     @OneToOne
     @JoinColumn(name = "assetIdWallpaper")
     private Asset wallpaperAsset;
+    private String sportPreset;
+    private String customSportName;
 }

--- a/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/ErrorCodes.java
@@ -14,6 +14,7 @@ public enum ErrorCodes {
     GROUP_INVITE_CODE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "groupInviteCodeNotProvided", "The invite code needs to be provided!"),
     INVALID_GROUP_NAME(HttpStatus.BAD_REQUEST, "invalidGroupName", "Group name must be non-null, non-empty and between 2 and 50 characters!"),
     INVALID_GROUP_PROFILE_NAMES(HttpStatus.BAD_REQUEST, "invalidGroupProfileNames", "Group profileNames must be non-null and non-empty!"),
+    INVALID_GROUP_SPORT(HttpStatus.BAD_REQUEST, "invalidGroupSport", "Either a valid preset-id has to be set to 'sportPreset' or a non-null, non-empty 'customSportName' has to be supplied!"),
     INVALID_GROUP_INVITE_CODE(HttpStatus.BAD_REQUEST, "invalidGroupInviteCode", "Group invite code must be non-null and non-empty!"),
     INVALID_GROUP_ID(HttpStatus.BAD_REQUEST, "invalidGroupId", "Group id must be non-null and non-empty!"),
     /* SEASONS */

--- a/api/src/main/java/pro/beerpong/api/model/dto/GroupCreateDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/GroupCreateDto.java
@@ -12,8 +12,8 @@ public class GroupCreateDto {
 
     private String name;
     private List<String> profileNames;
-    private String sportPresetId;
-    private String customSport;
+    private String sportPreset;
+    private String customSportName;
 
     public boolean invalidName() {
         return this.name == null || this.name.isEmpty() ||

--- a/api/src/main/java/pro/beerpong/api/model/dto/GroupCreateDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/GroupCreateDto.java
@@ -12,6 +12,8 @@ public class GroupCreateDto {
 
     private String name;
     private List<String> profileNames;
+    private String sportPresetId;
+    private String customSport;
 
     public boolean invalidName() {
         return this.name == null || this.name.isEmpty() ||

--- a/api/src/main/java/pro/beerpong/api/model/dto/GroupDto.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/GroupDto.java
@@ -12,6 +12,8 @@ public class GroupDto {
     private Season activeSeason;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private AssetMetadataDto wallpaperAsset;
+    private GroupPreset sportPreset;
+    private String customSportName;
     private int numberOfPlayers;
     private int numberOfMatches;
     private int numberOfSeasons;

--- a/api/src/main/java/pro/beerpong/api/model/dto/GroupPreset.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/GroupPreset.java
@@ -1,0 +1,12 @@
+package pro.beerpong.api.model.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GroupPreset {
+    private final String id;
+    private final String title;
+    private final String imageUrl;
+}

--- a/api/src/main/java/pro/beerpong/api/model/dto/GroupPreset.java
+++ b/api/src/main/java/pro/beerpong/api/model/dto/GroupPreset.java
@@ -3,10 +3,24 @@ package pro.beerpong.api.model.dto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Objects;
+
 @Getter
 @RequiredArgsConstructor
 public class GroupPreset {
     private final String id;
     private final String title;
     private final String imageUrl;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        GroupPreset that = (GroupPreset) o;
+        return Objects.equals(id, that.id) && Objects.equals(title, that.title) && Objects.equals(imageUrl, that.imageUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, title, imageUrl);
+    }
 }

--- a/api/src/main/java/pro/beerpong/api/service/GroupService.java
+++ b/api/src/main/java/pro/beerpong/api/service/GroupService.java
@@ -45,6 +45,13 @@ public class GroupService {
         Group group = groupMapper.groupCreateDtoToGroup(groupCreateDto);
         group.setInviteCode(generateRandomString(GROUP_INVITE_CODE_LENGTH));
 
+        if (group.getSportPreset() != null && group.getCustomSportName() != null) {
+            group.setCustomSportName(null);
+        } else if ((group.getCustomSportName() != null && group.getCustomSportName().isBlank()) ||
+                (group.getSportPreset() == null && group.getCustomSportName() == null)) {
+            return null;
+        }
+
         var season = new Season();
         season.setStartDate(ZonedDateTime.now());
         season.setSeasonSettings(new SeasonSettings());
@@ -62,7 +69,7 @@ public class GroupService {
             profileService.createProfile(finalGroup.getId(), profileDto);
         });
 
-        ruleMoveService.createDefaultRuleMoves(season);
+        ruleMoveService.createDefaultRuleMoves(group, season);
         ruleService.createDefaultRules(season);
 
         return withStats(groupMapper.groupToGroupDto(group));

--- a/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
+++ b/api/src/main/java/pro/beerpong/api/service/RuleMoveService.java
@@ -3,6 +3,7 @@ package pro.beerpong.api.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
+import pro.beerpong.api.control.GroupPresetsController;
 import pro.beerpong.api.mapping.RuleMoveMapper;
 import pro.beerpong.api.model.dao.Group;
 import pro.beerpong.api.model.dao.RuleMove;
@@ -16,10 +17,11 @@ import pro.beerpong.api.sockets.SocketEventData;
 import pro.beerpong.api.sockets.SubscriptionHandler;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @Service
 public class RuleMoveService {
-    private static final List<RuleMove> DEFAULT_RULE_MOVES = List.of(
+    private static final List<RuleMove> DEFAULT_BEERPONG_MOVES = List.of(
             buildRuleMove("Normal", 1, 0, false),
             buildRuleMove("Bomb", 2, 0, false),
             buildRuleMove("Bouncer", 2, 0, false),
@@ -27,6 +29,11 @@ public class RuleMoveService {
             buildRuleMove("Save", 2, 0, false),
             buildRuleMove("Finish - Normal", 1, 3, true),
             buildRuleMove("Finish - Ring of fire", 1, 10, true)
+    );
+
+    private static final List<RuleMove> DEFAULT_MOVES = List.of(
+            buildRuleMove("Normal", 1, 0, false),
+            buildRuleMove("Finish - Normal", 1, 3, true)
     );
 
     private final SubscriptionHandler subscriptionHandler;
@@ -121,9 +128,16 @@ public class RuleMoveService {
         });
     }
 
-    public void createDefaultRuleMoves(Season season) {
-        DEFAULT_RULE_MOVES.stream()
-                .map(ruleMove -> {
+    public void createDefaultRuleMoves(Group group, Season season) {
+        Stream<RuleMove> ruleMoves;
+
+        if (group.getSportPreset() != null && group.getSportPreset().equals(GroupPresetsController.BEERPONG.getId())) {
+            ruleMoves = DEFAULT_BEERPONG_MOVES.stream();
+        } else {
+            ruleMoves = DEFAULT_MOVES.stream();
+        }
+
+        ruleMoves.map(ruleMove -> {
                     var move = ruleMove.clone();
                     move.setSeason(season);
                     return move;

--- a/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
+++ b/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
@@ -36,6 +36,7 @@ public class CreateMatchTest {
         var createGroupDto = new GroupCreateDto();
         createGroupDto.setProfileNames(List.of("player1", "player2", "player3", "player4"));
         createGroupDto.setName("test");
+        createGroupDto.setSportPreset("beerpong");
 
         var prerequisiteGroupResponse = testUtils.performPost(port, "/groups", createGroupDto, GroupDto.class);
 
@@ -203,6 +204,7 @@ public class CreateMatchTest {
         var createGroupDto = new GroupCreateDto();
         createGroupDto.setProfileNames(List.of("player1", "player2", "player3", "player4"));
         createGroupDto.setName("test-update");
+        createGroupDto.setSportPreset("beerpong");
 
         var groupResponse = testUtils.performPost(port, "/groups", createGroupDto, GroupDto.class);
         ResponseEnvelope<GroupDto> groupEnvelope = (ResponseEnvelope<GroupDto>) groupResponse.getBody();
@@ -282,6 +284,7 @@ public class CreateMatchTest {
 //        var createGroupDto = new GroupCreateDto();
 //        createGroupDto.setProfileNames(List.of("player1", "player2"));
 //        createGroupDto.setName("test-get");
+    //createGroupDto.setSportPreset("beerpong");
 //
 //        var groupResponse = testUtils.performPost(port, "/groups", createGroupDto, GroupDto.class);
 //        ResponseEnvelope<GroupDto> groupEnvelope = (ResponseEnvelope<GroupDto>) groupResponse.getBody();

--- a/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
+++ b/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
@@ -51,7 +51,7 @@ public class CreateMatchTest {
         assertEquals(200, prerequisiteEnvelope.getHttpCode());
 
         var prerequisiteGroup = prerequisiteEnvelope.getData();
-        assertEquals(GroupPresetsController.BEERPONG, prerequisiteGroup.getSportPreset());
+        assertEquals(GroupPresetsController.BEERPONG.getId(), prerequisiteGroup.getSportPreset().getId());
         var response = testUtils.performGet(port, "/groups?inviteCode=" + prerequisiteGroup.getInviteCode(), GroupDto.class);
 
         assertNotNull(response);

--- a/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
+++ b/api/src/test/java/pro/beerpong/api/CreateMatchTest.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
+import pro.beerpong.api.control.GroupPresetsController;
 import pro.beerpong.api.model.dto.*;
 
 import java.util.List;
@@ -50,7 +51,7 @@ public class CreateMatchTest {
         assertEquals(200, prerequisiteEnvelope.getHttpCode());
 
         var prerequisiteGroup = prerequisiteEnvelope.getData();
-
+        assertEquals(GroupPresetsController.BEERPONG, prerequisiteGroup.getSportPreset());
         var response = testUtils.performGet(port, "/groups?inviteCode=" + prerequisiteGroup.getInviteCode(), GroupDto.class);
 
         assertNotNull(response);
@@ -63,7 +64,6 @@ public class CreateMatchTest {
         assertEquals(200, envelope.getHttpCode());
 
         var group = envelope.getData();
-
         // if this is not here, the startDate millis are rounded and this test fails
         group.getActiveSeason().setStartDate(prerequisiteGroup.getActiveSeason().getStartDate());
 

--- a/api/src/test/java/pro/beerpong/api/control/GroupControllerTest.java
+++ b/api/src/test/java/pro/beerpong/api/control/GroupControllerTest.java
@@ -54,7 +54,7 @@ public class GroupControllerTest {
         assertNotNull(group.getActiveSeason());
         assertNotNull(group.getActiveSeason().getId());
         assertEquals(group.getActiveSeason().getGroupId(), group.getId());
-        assertEquals(GroupPresetsController.BEERPONG, group.getSportPreset());
+        assertEquals(GroupPresetsController.BEERPONG.getId(), group.getSportPreset().getId());
     }
 
     @Test

--- a/api/src/test/java/pro/beerpong/api/control/GroupControllerTest.java
+++ b/api/src/test/java/pro/beerpong/api/control/GroupControllerTest.java
@@ -54,6 +54,7 @@ public class GroupControllerTest {
         assertNotNull(group.getActiveSeason());
         assertNotNull(group.getActiveSeason().getId());
         assertEquals(group.getActiveSeason().getGroupId(), group.getId());
+        assertEquals(GroupPresetsController.BEERPONG, group.getSportPreset());
     }
 
     @Test
@@ -102,5 +103,6 @@ public class GroupControllerTest {
         assertNotNull(group.getActiveSeason());
         assertNotNull(group.getActiveSeason().getId());
         assertEquals(group.getActiveSeason().getGroupId(), group.getId());
+        assertEquals(group.getSportPreset(), prerequisiteGroup.getSportPreset());
     }
 }

--- a/api/src/test/java/pro/beerpong/api/control/GroupControllerTest.java
+++ b/api/src/test/java/pro/beerpong/api/control/GroupControllerTest.java
@@ -31,6 +31,7 @@ public class GroupControllerTest {
         var createDto = new GroupCreateDto();
         createDto.setProfileNames(List.of("player1", "player2"));
         createDto.setName("test");
+        createDto.setSportPreset("beerpong");
 
         var response = testUtils.performPost(port, "/groups", createDto, GroupDto.class);
 
@@ -62,6 +63,7 @@ public class GroupControllerTest {
         var createDto = new GroupCreateDto();
         createDto.setProfileNames(List.of("player1", "player2"));
         createDto.setName("test");
+        createDto.setSportPreset("beerpong");
 
         var prerequisiteResponse = testUtils.performPost(port, "/groups", createDto, GroupDto.class);
 

--- a/mobile-app/api/generated/openapi.json
+++ b/mobile-app/api/generated/openapi.json
@@ -1011,6 +1011,24 @@
                 }
             }
         },
+        "/group-presets": {
+            "get": {
+                "tags": ["group-presets-controller"],
+                "operationId": "getPresets",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseEnvelopeListGroupPreset"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/assets/{id}": {
             "get": {
                 "tags": ["asset-controller"],
@@ -1109,7 +1127,9 @@
                     "profileNames": {
                         "type": "array",
                         "items": { "type": "string" }
-                    }
+                    },
+                    "sportPreset": { "type": "string" },
+                    "customSportName": { "type": "string" }
                 }
             },
             "AssetMetadataDto": {
@@ -1138,9 +1158,21 @@
                     "wallpaperAsset": {
                         "$ref": "#/components/schemas/AssetMetadataDto"
                     },
+                    "sportPreset": {
+                        "$ref": "#/components/schemas/GroupPreset"
+                    },
+                    "customSportName": { "type": "string" },
                     "numberOfPlayers": { "type": "integer", "format": "int32" },
                     "numberOfMatches": { "type": "integer", "format": "int32" },
                     "numberOfSeasons": { "type": "integer", "format": "int32" }
+                }
+            },
+            "GroupPreset": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "title": { "type": "string" },
+                    "imageUrl": { "type": "string" }
                 }
             },
             "ResponseEnvelopeGroupDto": {
@@ -1607,6 +1639,18 @@
                     "status": { "type": "string", "enum": ["OK", "ERROR"] },
                     "httpCode": { "type": "integer", "format": "int32" },
                     "data": { "$ref": "#/components/schemas/LeaderboardDto" },
+                    "error": { "$ref": "#/components/schemas/ErrorDetails" }
+                }
+            },
+            "ResponseEnvelopeListGroupPreset": {
+                "type": "object",
+                "properties": {
+                    "status": { "type": "string", "enum": ["OK", "ERROR"] },
+                    "httpCode": { "type": "integer", "format": "int32" },
+                    "data": {
+                        "type": "array",
+                        "items": { "$ref": "#/components/schemas/GroupPreset" }
+                    },
                     "error": { "$ref": "#/components/schemas/ErrorDetails" }
                 }
             }

--- a/mobile-app/openapi/openapi.d.ts
+++ b/mobile-app/openapi/openapi.d.ts
@@ -21,6 +21,8 @@ declare namespace Components {
         export interface GroupCreateDto {
             name?: string;
             profileNames?: string[];
+            sportPreset?: string;
+            customSportName?: string;
         }
         export interface GroupDto {
             id?: string;
@@ -28,9 +30,16 @@ declare namespace Components {
             inviteCode?: string;
             activeSeason?: Season;
             wallpaperAsset?: AssetMetadataDto;
+            sportPreset?: GroupPreset;
+            customSportName?: string;
             numberOfPlayers?: number; // int32
             numberOfMatches?: number; // int32
             numberOfSeasons?: number; // int32
+        }
+        export interface GroupPreset {
+            id?: string;
+            title?: string;
+            imageUrl?: string;
         }
         export interface LeaderboardDto {
             entries?: LeaderboardEntryDto[];
@@ -121,6 +130,12 @@ declare namespace Components {
             status?: 'OK' | 'ERROR';
             httpCode?: number; // int32
             data?: LeaderboardDto;
+            error?: ErrorDetails;
+        }
+        export interface ResponseEnvelopeListGroupPreset {
+            status?: 'OK' | 'ERROR';
+            httpCode?: number; // int32
+            data?: GroupPreset[];
             error?: ErrorDetails;
         }
         export interface ResponseEnvelopeListMatchDto {
@@ -521,6 +536,12 @@ declare namespace Paths {
         }
         namespace Responses {
             export type $200 = Components.Schemas.ResponseEnvelopeListPlayerDto;
+        }
+    }
+    namespace GetPresets {
+        namespace Responses {
+            export type $200 =
+                Components.Schemas.ResponseEnvelopeListGroupPreset;
         }
     }
     namespace GetProfileById {
@@ -940,6 +961,14 @@ export interface OperationMethods {
         config?: AxiosRequestConfig
     ): OperationResponse<Paths.GetLeaderboard.Responses.$200>;
     /**
+     * getPresets
+     */
+    'getPresets'(
+        parameters?: Parameters<UnknownParamsObject> | null,
+        data?: any,
+        config?: AxiosRequestConfig
+    ): OperationResponse<Paths.GetPresets.Responses.$200>;
+    /**
      * getAsset
      */
     'getAsset'(
@@ -1242,6 +1271,16 @@ export interface PathsDictionary {
             config?: AxiosRequestConfig
         ): OperationResponse<Paths.GetLeaderboard.Responses.$200>;
     };
+    ['/group-presets']: {
+        /**
+         * getPresets
+         */
+        'get'(
+            parameters?: Parameters<UnknownParamsObject> | null,
+            data?: any,
+            config?: AxiosRequestConfig
+        ): OperationResponse<Paths.GetPresets.Responses.$200>;
+    };
     ['/assets/{id}']: {
         /**
          * getAsset
@@ -1280,6 +1319,7 @@ export type AssetMetadataDto = Components.Schemas.AssetMetadataDto;
 export type ErrorDetails = Components.Schemas.ErrorDetails;
 export type GroupCreateDto = Components.Schemas.GroupCreateDto;
 export type GroupDto = Components.Schemas.GroupDto;
+export type GroupPreset = Components.Schemas.GroupPreset;
 export type LeaderboardDto = Components.Schemas.LeaderboardDto;
 export type LeaderboardEntryDto = Components.Schemas.LeaderboardEntryDto;
 export type MatchCreateDto = Components.Schemas.MatchCreateDto;
@@ -1300,6 +1340,8 @@ export type ResponseEnvelopeGroupDto =
     Components.Schemas.ResponseEnvelopeGroupDto;
 export type ResponseEnvelopeLeaderboardDto =
     Components.Schemas.ResponseEnvelopeLeaderboardDto;
+export type ResponseEnvelopeListGroupPreset =
+    Components.Schemas.ResponseEnvelopeListGroupPreset;
 export type ResponseEnvelopeListMatchDto =
     Components.Schemas.ResponseEnvelopeListMatchDto;
 export type ResponseEnvelopeListMatchOverviewDto =


### PR DESCRIPTION
- Added `GET /group-presets` endpoint, returning a list of all supported games
- Added `sportPreset` and `customSportName` columns to the `groups` db
- When creating a group you either have to define a valid (based on group-presets results) `sportPreset` string or a non-blank `customSportName` string. If a valid preset is defined, the backend always uses that and overwirtes anything in customSportName with null
- Added sportPreset and customSportName to group dto everywhere

closes #168 