### PR TITLE
Adapt mobile app to lazy-loaded backend DTOs

### DIFF
--- a/mobile-app/api/calls/assetHooks.ts
+++ b/mobile-app/api/calls/assetHooks.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { ApiId } from '@/api/types';
+import { useApi } from '@/api/utils/create-api';
+import { Paths } from '@/openapi/openapi';
+
+export const useAssetQuery = (assetId: ApiId | null | undefined) => {
+    const { api } = useApi();
+
+    return useQuery<Paths.GetAsset.Responses.$200 | null>({
+        queryKey: ['asset', assetId ?? 'NULL'],
+        queryFn: async () => {
+            if (!assetId) {
+                return null;
+            }
+            const res = await (await api).getAsset(assetId);
+            return res?.data;
+        },
+        enabled: !!assetId,
+    });
+};

--- a/mobile-app/api/calls/matchHooks.ts
+++ b/mobile-app/api/calls/matchHooks.ts
@@ -38,13 +38,15 @@ export const useMatchesQuery = (
 ) => {
     const { api } = useApi();
 
-    return useQuery<Paths.GetAllMatches.Responses.$200 | null>({
+    return useQuery<Paths.GetAllMatchesExtended.Responses.$200 | null>({
         queryKey: [QK.group, groupId, QK.season, seasonId, QK.matches],
         queryFn: async () => {
             if (!groupId || !seasonId) {
                 return null;
             }
-            const res = await (await api).getAllMatches({ groupId, seasonId });
+            const res = await (
+                await api
+            ).getAllMatchesExtended({ groupId, seasonId });
 
             return res?.data;
         },
@@ -172,8 +174,7 @@ export const useUpdateMatchPhotoMutation = () => {
             });
 
             await uploadImage(
-                // @ts-expect-error TODO: broken typegen for AssetUploadResponse
-                res?.data.data?.photoAsset?.singleUploadUrl,
+                res?.data.data?.singleUploadUrl!,
                 byteArray,
                 'matchPhoto',
                 mimeType

--- a/mobile-app/api/calls/playerHooks.ts
+++ b/mobile-app/api/calls/playerHooks.ts
@@ -8,6 +8,21 @@ import { uploadImage } from '@/api/utils/uploadImage';
 import { Paths } from '@/openapi/openapi';
 import { ConsoleLogger } from '@/utils/logging';
 
+export const useProfilesQuery = (groupId: ApiId | null) => {
+    const { api } = useApi();
+
+    return useQuery<Paths.ListAllProfiles.Responses.$200 | null>({
+        queryKey: [QK.group, groupId ?? 'NULL', 'profiles'],
+        queryFn: async () => {
+            if (!groupId) {
+                return null;
+            }
+            const res = await (await api).listAllProfiles(groupId);
+            return res?.data;
+        },
+    });
+};
+
 export const usePlayersQuery = (
     groupId: ApiId | null,
     seasonId: ApiId | null | undefined
@@ -95,8 +110,7 @@ export const useUpdatePlayerAvatarMutation = () => {
                 id: profileId,
             });
             await uploadImage(
-                // @ts-expect-error TODO: broken typegen for AssetUploadResponse
-                res?.data.data?.avatarAsset?.singleUploadUrl,
+                res?.data.data?.singleUploadUrl!,
                 byteArray,
                 'profilePicture',
                 mimeType

--- a/mobile-app/api/calls/seasonHooks.ts
+++ b/mobile-app/api/calls/seasonHooks.ts
@@ -7,12 +7,13 @@ import { captureMutationErr } from '@/api/utils/captureException';
 import { useApi } from '@/api/utils/create-api';
 import { QK } from '@/api/utils/reactQuery';
 import {
-    MatchDto,
+    MatchDtoExtended,
     Paths,
-    PlayerDto,
+    PlayerDtoExtended,
+    ProfileDto,
     RuleMoveDto,
     SeasonDto,
-    SeasonSettings,
+    SeasonSettingsDto,
 } from '@/openapi/openapi';
 import { useGroupStore } from '@/zustand/group/stateGroupStore';
 
@@ -49,8 +50,8 @@ export const useAllSeasonsQuery = (groupId: ApiId | null) => {
               data?: (SeasonDto & {
                   numMatches: number;
                   players: Player[];
-                  rawPlayers: PlayerDto[];
-                  matches: MatchDto[];
+                  rawPlayers: PlayerDtoExtended[];
+                  matches: MatchDtoExtended[];
                   ruleMoves: RuleMoveDto[] | undefined;
               })[];
           })
@@ -65,11 +66,14 @@ export const useAllSeasonsQuery = (groupId: ApiId | null) => {
 
             const rawSeasons = res.data.data ?? [];
 
+            const profiles = await (await api).listAllProfiles(groupId);
+            const profileList = profiles.data.data ?? [];
+
             const seasons = await Promise.all(
                 rawSeasons.map(async (season) => {
                     const matches = await (
                         await api
-                    ).getAllMatches({
+                    ).getAllMatchesExtended({
                         groupId,
                         seasonId: season.id!,
                     });
@@ -94,7 +98,9 @@ export const useAllSeasonsQuery = (groupId: ApiId | null) => {
                     return {
                         ...season,
                         numMatches: matches.data.data?.length ?? 0,
-                        players: players.map(toPlayer),
+                        players: players.map((p) =>
+                            toPlayer(p, profileList)
+                        ),
                         rawPlayers: players,
                         matches: matches.data.data ?? [],
                         ruleMoves: ruleMoves.data.data,
@@ -127,19 +133,32 @@ export const useStartNewSeasonMutation = () => {
 /**
  * returns information about the group we're currently in
  *
- * mainly used for getting `groupId` and `seasonId` since we need these for so many queries
+ * mainly used for getting `groupId` and `seasonId` since we need these for so many queries.
+ * Also fetches the active season separately (since GroupDto only contains activeSeasonId).
  */
 export const useGroup = () => {
     const { selectedGroupId } = useGroupStore();
 
     const { data: groupQueryData } = useGroupQuery(selectedGroupId);
 
-    const seasonId = groupQueryData?.data?.activeSeason?.id;
+    const seasonId = groupQueryData?.data?.activeSeasonId;
+
+    const { data: seasonData } = useSeasonQuery(selectedGroupId, seasonId ?? null);
+
+    const groupDataWithSeason = groupQueryData?.data
+        ? {
+              ...groupQueryData.data,
+              activeSeason: seasonData?.data,
+          }
+        : undefined;
 
     return {
         groupId: selectedGroupId,
         seasonId,
-        group: { ...(groupQueryData ?? {}) },
+        group: {
+            ...(groupQueryData ?? {}),
+            data: groupDataWithSeason,
+        },
     };
 };
 
@@ -170,11 +189,11 @@ export function useSeasonSettings(groupId: ApiId, seasonId: ApiId) {
     const seasonQuery = useSeasonQuery(groupId, seasonId);
 
     const seasonSettings = seasonQuery.data?.data?.seasonSettings as
-        | Required<SeasonSettings>
+        | Required<SeasonSettingsDto>
         | undefined;
 
     const updateSeasonSettingsMutation = useMutation({
-        mutationFn: async (partialUpdate: Omit<SeasonSettings, 'id'>) => {
+        mutationFn: async (partialUpdate: Omit<SeasonSettingsDto, 'id'>) => {
             if (!groupId || !seasonId || !seasonSettings) return;
 
             qc.setQueryData([QK.group, groupId, QK.seasons, seasonId], {
@@ -222,16 +241,20 @@ export interface Player {
     cups: number;
 }
 
-export const toPlayer = (i: PlayerDto): Player => {
+export const toPlayer = (
+    i: PlayerDtoExtended,
+    profiles: ProfileDto[] = []
+): Player => {
+    const profile = profiles.find((p) => p.id === i.profileId);
     return {
         id: i!.id!,
         elo: i.statistics?.elo ?? 0, // actually nullable from the backend
         matches: i.statistics?.matches!,
         points: i.statistics?.points!,
         matchesWon: i.statistics?.wins!,
-        name: i.profile?.name!,
-        avatarUrl: i!.profile?.avatarAsset?.url,
-        profileId: i!.profile?.id!,
+        name: profile?.name ?? 'Unknown',
+        avatarUrl: profile?.assetIdAvatar ?? null,
+        profileId: i.profileId!,
         cups: i.statistics?.moves ?? 0,
     };
 };

--- a/mobile-app/api/entities/index.ts
+++ b/mobile-app/api/entities/index.ts
@@ -72,11 +72,11 @@ export class MatchMoveImpl {
 export class ProfileImpl {
     public id: string;
     public name: string;
-    public avatarUrl: string | null;
+    public avatarAssetId: string | null;
 
     constructor(_data: Components.Schemas.ProfileDto) {
         this.name = _data.name!;
-        this.avatarUrl = _data.avatarAsset?.url ?? null;
+        this.avatarAssetId = _data.assetIdAvatar ?? null;
         this.id = _data.id!;
     }
 }
@@ -86,7 +86,7 @@ export class TeamMemberImpl {
     public team!: 'red' | 'blue';
 
     public get name(): string {
-        return this.player?.profile?.name;
+        return "TODO";
     }
     // TODO: implement this
     public get change(): number {
@@ -126,7 +126,7 @@ export class TeamMemberImpl {
     }
 
     public get avatarUrl(): string | null {
-        return this.player?.profile?.avatarUrl;
+        return null;
     }
 
     public setTeamColor(color: 'red' | 'blue'): void {
@@ -172,18 +172,16 @@ export class PlayerImpl {
     public id: string;
 
     public profileId: string;
-    public profile: ProfileImpl;
+    public active: boolean;
 
     public setProfile(profile: ProfileImpl): void {
-        this.profile = profile;
         this.profileId = profile.id;
     }
 
     constructor(_data: Components.Schemas.PlayerDto) {
         this.id = _data.id!;
-
-        this.profileId = _data.profile!.id!;
-        this.profile = new ProfileImpl(_data.profile!);
+        this.active = _data.activeThisSeason!;
+        this.profileId = _data.profileId!;
     }
 }
 
@@ -211,8 +209,8 @@ export class MatchImpl {
     public id: string;
     public date: Date;
     public seasonId: string;
-    public blueTeamPhotoUrl?: string | null;
-    public redTeamPhotoUrl?: string | null;
+    public blueTeamPhotoAssetId?: string | null;
+    public redTeamPhotoAssetId?: string | null;
 
     public teams: TeamImpl[];
 
@@ -252,7 +250,7 @@ export class MatchImpl {
     private ruleMoves: RuleMoveImpl[];
 
     constructor(
-        _data: Omit<Components.Schemas.MatchDto, 'date'> & {
+        _data: Omit<Components.Schemas.MatchDtoExtended, 'date'> & {
             date?: string | Date;
         },
         _players: Components.Schemas.PlayerDto[],
@@ -264,12 +262,12 @@ export class MatchImpl {
             );
         }
 
-        this.seasonId = _data.season!.id!;
+        this.seasonId = _data.seasonId!;
         this.id = _data.id!;
         this.date = new Date(_data.date!);
         this.teams = _data.teams!.map((i) => new TeamImpl(i));
-        this.blueTeamPhotoUrl = _data.teams[0]?.photoAsset?.url ?? null;
-        this.redTeamPhotoUrl = _data.teams[1]?.photoAsset?.url ?? null;
+        this.blueTeamPhotoAssetId = _data.teams[0]?.photoAssetId ?? null;
+        this.redTeamPhotoAssetId = _data.teams[1]?.photoAssetId ?? null;
 
         const players = _players.map((i) => new PlayerImpl(i));
         const ruleMoves = _ruleMoves.map((i) => new RuleMoveImpl(i));
@@ -339,8 +337,8 @@ export class MatchImpl {
             redCups: this.redCups,
             blueTeamId: this._blueTeam.id,
             redTeamId: this._redTeam.id,
-            blueTeamPhotoUrl: this.blueTeamPhotoUrl,
-            redTeamPhotoUrl: this.redTeamPhotoUrl,
+            blueTeamPhotoAssetId: this.blueTeamPhotoAssetId,
+            redTeamPhotoAssetId: this.redTeamPhotoAssetId,
 
             blueTeam: this.blueTeam.map((i) => {
                 const player = i.toJSON();

--- a/mobile-app/api/generated/openapi.json
+++ b/mobile-app/api/generated/openapi.json
@@ -1580,10 +1580,9 @@
                 "properties": {
                     "id": { "type": "string" },
                     "name": { "type": "string" },
-                    "avatarAsset": {
-                        "$ref": "#/components/schemas/AssetMetadataDto"
-                    },
-                    "groupId": { "type": "string" }
+                    "assetIdAvatar": { "type": "string" },
+                    "groupId": { "type": "string" },
+                    "createdById": { "type": "string" }
                 }
             },
             "ResponseEnvelopeProfileDto": {
@@ -1668,7 +1667,7 @@
                 "type": "object",
                 "properties": {
                     "id": { "type": "string" },
-                    "profile": { "$ref": "#/components/schemas/ProfileDto" },
+                    "profileId": { "type": "string" },
                     "season": { "$ref": "#/components/schemas/SeasonDto" },
                     "activeThisSeason": { "type": "boolean" },
                     "statistics": {

--- a/mobile-app/api/utils/matchDtoToMatch.ts
+++ b/mobile-app/api/utils/matchDtoToMatch.ts
@@ -37,8 +37,8 @@ export type Match = {
 
     winnerTeamId: string | null;
 
-    blueTeamPhotoUrl?: string | null;
-    redTeamPhotoUrl?: string | null;
+    blueTeamPhotoAssetId?: string | null;
+    redTeamPhotoAssetId?: string | null;
 };
 
 export const matchDtoToMatch =
@@ -46,7 +46,7 @@ export const matchDtoToMatch =
         players: Components.Schemas.PlayerDto[] = [],
         allowedMoves: Components.Schemas.RuleMoveDto[] = []
     ) =>
-    (i: Components.Schemas.MatchDto): Match => {
+    (i: Components.Schemas.MatchDtoExtended): Match => {
         return new MatchImpl(i, players, allowedMoves).toJSON();
     };
 

--- a/mobile-app/app/(tabs)/newMatch.tsx
+++ b/mobile-app/app/(tabs)/newMatch.tsx
@@ -11,7 +11,7 @@ import {
     useMatchesQuery,
     useUpdateMatchPhotoMutation,
 } from '@/api/calls/matchHooks';
-import { usePlayersQuery } from '@/api/calls/playerHooks';
+import { usePlayersQuery, useProfilesQuery } from '@/api/calls/playerHooks';
 import { useMoves } from '@/api/calls/ruleHooks';
 import { useGroup } from '@/api/calls/seasonHooks';
 import { matchDtoToMatch } from '@/api/utils/matchDtoToMatch';
@@ -100,6 +100,10 @@ export default function NewMatchScreen() {
 
     const playersQuery = usePlayersQuery(groupId, seasonId);
 
+    const profilesQuery = useProfilesQuery(groupId);
+
+    const profilesList = profilesQuery.data?.data ?? [];
+
     const matchDraft = useMatchDraftStore();
 
     const hasValidTeams =
@@ -124,24 +128,28 @@ export default function NewMatchScreen() {
 
     const [swiperPage, setSwiperPage] = useState(0);
 
-    const profiles = playersQuery.data?.data ?? [];
+    const players = playersQuery.data?.data ?? [];
 
-    const selectablePlayers = profiles
+    const selectablePlayers = players
         .filter((i) => i.activeThisSeason)
-        .map<Player>((i) => ({
-            id: i.id!,
-            name: i.profile?.name || 'Unknown',
-            team:
-                matchDraft.actions.getPlayers().find((j) => i.id === j.playerId)
-                    ?.team ?? null,
+        .map<Player>((i) => {
+            const profile = profilesList.find((j) => j.id === i.profileId);
+            return {
+                id: i.id!,
+                name: profile?.name || 'Unknown',
+                team:
+                    matchDraft.actions.getPlayers().find((j) => i.id === j.playerId)
+                        ?.team ?? null,
 
-            avatarUrl: i.profile?.avatarAsset?.url,
-        }));
+                avatarUrl: profile?.assetIdAvatar,
+            };
+        });
 
     const displayMatch = getDisplayMatch(
         matchDraft.actions.getPlayers(),
         group.data?.activeSeason?.seasonSettings?.rankingAlgorithm,
         playersQuery.data?.data ?? [],
+        profilesList,
         matches,
         movesQuery.data?.data ?? []
     );

--- a/mobile-app/app/assignCupHitModal.tsx
+++ b/mobile-app/app/assignCupHitModal.tsx
@@ -2,7 +2,7 @@ import { Stack, useLocalSearchParams } from 'expo-router';
 import React, { useState } from 'react';
 import { View } from 'react-native';
 
-import { usePlayersQuery } from '@/api/calls/playerHooks';
+import { usePlayersQuery, useProfilesQuery } from '@/api/calls/playerHooks';
 import { useMoves } from '@/api/calls/ruleHooks';
 import { useGroup } from '@/api/calls/seasonHooks';
 import { TeamMember } from '@/api/utils/matchDtoToMatch';
@@ -40,22 +40,27 @@ export default function Page() {
 
     const playersQuery = usePlayersQuery(groupId, seasonId);
 
-    const profiles = playersQuery.data?.data ?? [];
+    const playersList = playersQuery.data?.data ?? [];
+
+    const profilesQuery = useProfilesQuery(groupId);
+
+    const profilesList = profilesQuery.data?.data ?? [];
 
     const players = matchDraft.actions.getPlayers();
 
     const teamMembers = players.map<TeamMember>((i) => {
-        const profile = profiles.find((j) => i.playerId === j.id);
+        const player = playersList.find((j) => i.playerId === j.id);
+        const profile = profilesList.find((j) => j.id === player?.profileId);
 
-        if (!profile?.profile?.name) {
+        if (!profile?.name) {
             ConsoleLogger.error('failed to get profile for team member');
         }
 
         return {
             id: i.playerId,
             team: i.team,
-            avatarUrl: profile?.profile?.avatarAsset?.url,
-            name: profile?.profile?.name || 'Unknown',
+            avatarUrl: profile?.assetIdAvatar,
+            name: profile?.name || 'Unknown',
             points: i.moves.reduce(
                 (sum, j) =>
                     sum +

--- a/mobile-app/app/assignPointsToPlayerModal.tsx
+++ b/mobile-app/app/assignPointsToPlayerModal.tsx
@@ -1,7 +1,7 @@
 import { useLocalSearchParams } from 'expo-router';
 import React from 'react';
 
-import { usePlayersQuery } from '@/api/calls/playerHooks';
+import { usePlayersQuery, useProfilesQuery } from '@/api/calls/playerHooks';
 import { useMoves } from '@/api/calls/ruleHooks';
 import { useGroup } from '@/api/calls/seasonHooks';
 import { MinimalMatch, TeamMember } from '@/api/utils/matchDtoToMatch';
@@ -27,22 +27,27 @@ export default function Page() {
 
     const playersQuery = usePlayersQuery(groupId, seasonId);
 
-    const profiles = playersQuery.data?.data ?? [];
+    const playersList = playersQuery.data?.data ?? [];
+
+    const profilesQuery = useProfilesQuery(groupId);
+
+    const profilesList = profilesQuery.data?.data ?? [];
 
     const players = matchDraft.actions.getPlayers();
 
     const teamMembers = players.map<TeamMember>((i) => {
-        const profile = profiles.find((j) => i.playerId === j.id);
+        const player = playersList.find((j) => i.playerId === j.id);
+        const profile = profilesList.find((j) => j.id === player?.profileId);
 
-        if (!profile?.profile?.name) {
+        if (!profile?.name) {
             ConsoleLogger.error('failed to get profile for team member');
         }
 
         return {
             id: i.playerId,
             team: i.team,
-            avatarUrl: profile?.profile?.avatarAsset?.url,
-            name: profile?.profile?.name || 'Unknown',
+            avatarUrl: profile?.assetIdAvatar,
+            name: profile?.name || 'Unknown',
             points: i.moves.reduce(
                 (sum, j) =>
                     sum +

--- a/mobile-app/app/createNewPlayer.tsx
+++ b/mobile-app/app/createNewPlayer.tsx
@@ -1,6 +1,7 @@
 import {
     useCreatePlayerMutation,
     usePlayersQuery,
+    useProfilesQuery,
 } from '@/api/calls/playerHooks';
 import { useGroup } from '@/api/calls/seasonHooks';
 import { useNavigation } from '@/app/navigation/useNavigation';
@@ -17,7 +18,14 @@ export default function Page() {
 
     const players = playersQuery.data?.data ?? [];
 
-    const existingPlayers = players.map((i) => i.profile!.name!);
+    const profilesQuery = useProfilesQuery(groupId);
+
+    const profilesList = profilesQuery.data?.data ?? [];
+
+    const existingPlayers = players.map((i) => {
+        const profile = profilesList.find((j) => j.id === i.profileId);
+        return profile?.name ?? '';
+    });
 
     const createPlayerMutation = useCreatePlayerMutation();
 

--- a/mobile-app/app/editMatchPoints.tsx
+++ b/mobile-app/app/editMatchPoints.tsx
@@ -1,6 +1,6 @@
 import { useLocalSearchParams } from 'expo-router';
 
-import { usePlayersQuery } from '@/api/calls/playerHooks';
+import { usePlayersQuery, useProfilesQuery } from '@/api/calls/playerHooks';
 import { useMoves } from '@/api/calls/ruleHooks';
 import { useGroup } from '@/api/calls/seasonHooks';
 import { MinimalMatch, TeamMember } from '@/api/utils/matchDtoToMatch';
@@ -25,24 +25,29 @@ export default function Page() {
 
     const playersQuery = usePlayersQuery(groupId, seasonId);
 
-    const profiles = playersQuery.data?.data ?? [];
+    const playersList = playersQuery.data?.data ?? [];
+
+    const profilesQuery = useProfilesQuery(groupId);
+
+    const profilesList = profilesQuery.data?.data ?? [];
 
     const matchDraft = useMatchEditDraftStore();
 
     const players = matchDraft.actions.getPlayers();
 
     const teamMembers = players.map<TeamMember>((i) => {
-        const profile = profiles.find((j) => i.playerId === j.id);
+        const player = playersList.find((j) => i.playerId === j.id);
+        const profile = profilesList.find((j) => j.id === player?.profileId);
 
-        if (!profile?.profile?.name) {
+        if (!profile?.name) {
             ConsoleLogger.error('failed to get profile for team member');
         }
 
         return {
             id: i.playerId,
             team: i.team,
-            avatarUrl: profile?.profile?.avatarAsset?.url,
-            name: profile?.profile?.name || 'Unknown',
+            avatarUrl: profile?.assetIdAvatar,
+            name: profile?.name || 'Unknown',
             points: i.moves.reduce(
                 (sum, j) =>
                     sum +

--- a/mobile-app/app/editPlayerName.tsx
+++ b/mobile-app/app/editPlayerName.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 
 import {
     usePlayersQuery,
+    useProfilesQuery,
     useUpdatePlayerMutation,
 } from '@/api/calls/playerHooks';
 import { useGroup } from '@/api/calls/seasonHooks';
@@ -19,13 +20,19 @@ export default function Page() {
 
     const playersQuery = usePlayersQuery(groupId, seasonId);
 
+    const profilesQuery = useProfilesQuery(groupId);
+
+    const profilesList = profilesQuery.data?.data ?? [];
+
     const { id } = useLocalSearchParams<{ id: string }>();
 
     const player = playersQuery.data?.data?.find((i) => i.id === id);
 
-    const profileId = player?.profile?.id;
+    const profile = profilesList.find((j) => j.id === player?.profileId);
 
-    const [value, setValue] = useState(player?.profile?.name || '');
+    const profileId = profile?.id;
+
+    const [value, setValue] = useState(profile?.name || '');
 
     const updatePlayerMutation = useUpdatePlayerMutation();
 

--- a/mobile-app/app/getDisplayMatch.ts
+++ b/mobile-app/app/getDisplayMatch.ts
@@ -4,21 +4,23 @@ import {
     TeamMember,
 } from '@/api/utils/matchDtoToMatch';
 import { TeamId } from '@/components/screens/NewMatchAssignTeams';
-import { PlayerDto, RuleMoveDto } from '@/openapi/openapi';
+import { PlayerDto, ProfileDto, RuleMoveDto } from '@/openapi/openapi';
 import { ConsoleLogger } from '@/utils/logging';
 import { PlayerDraft } from '@/zustand/matchEditDraftStore';
 
 export function getDisplayMatch(
     draftPlayers: (PlayerDraft & { team: TeamId })[],
     rankingAlgorithm: 'AVERAGE' | 'ELO' | undefined,
-    profiles: PlayerDto[],
+    players: PlayerDto[],
+    profilesList: ProfileDto[],
     matches: MinimalMatch[],
     allowedMoves: RuleMoveDto[]
 ): Omit<MinimalMatch, 'id' | 'date'> {
     const teamMembers = draftPlayers.map<TeamMember>((i) => {
-        const profile = profiles.find((j) => i.playerId === j.id);
+        const player = players.find((j) => i.playerId === j.id);
+        const profile = profilesList.find((j) => j.id === player?.profileId);
 
-        if (!profile?.profile?.name) {
+        if (!profile?.name) {
             ConsoleLogger.error('failed to get profile for team member'); // TODO: this happens sometimes for a split second
         }
 
@@ -60,8 +62,8 @@ export function getDisplayMatch(
                 };
             }),
 
-            avatarUrl: profile?.profile?.avatarAsset?.url,
-            name: profile?.profile?.name || 'Unknown',
+            avatarUrl: profile?.assetIdAvatar,
+            name: profile?.name || 'Unknown',
             profileId: profile?.id || '#',
         };
     });

--- a/mobile-app/app/match.tsx
+++ b/mobile-app/app/match.tsx
@@ -2,6 +2,7 @@ import { Stack, useLocalSearchParams } from 'expo-router';
 import React, { useEffect, useState } from 'react';
 import { ScrollView, View } from 'react-native';
 
+import { useAssetQuery } from '@/api/calls/assetHooks';
 import {
     useDeleteMatchMutation,
     useDeleteMatchPhotoMutation,
@@ -10,7 +11,7 @@ import {
     useUpdateMatchMutation,
     useUpdateMatchPhotoMutation,
 } from '@/api/calls/matchHooks';
-import { usePlayersQuery } from '@/api/calls/playerHooks';
+import { usePlayersQuery, useProfilesQuery } from '@/api/calls/playerHooks';
 import { useMoves } from '@/api/calls/ruleHooks';
 import { useGroup } from '@/api/calls/seasonHooks';
 import { matchDtoToMatch } from '@/api/utils/matchDtoToMatch';

--- a/mobile-app/openapi/openapi.d.ts
+++ b/mobile-app/openapi/openapi.d.ts
@@ -94,7 +94,7 @@ declare namespace Components {
         }
         export interface PlayerDto {
             id?: string;
-            profile?: ProfileDto;
+            profileId?: string;
             season?: SeasonDto;
             activeThisSeason?: boolean;
             statistics?: PlayerStatisticsDto;
@@ -128,8 +128,9 @@ declare namespace Components {
         export interface ProfileDto {
             id?: string;
             name?: string;
-            avatarAsset?: AssetMetadataDto;
+            assetIdAvatar?: string;
             groupId?: string;
+            createdById?: string;
         }
         export interface ResponseEnvelopeAssetMetadataDto {
             status?: 'OK' | 'ERROR';


### PR DESCRIPTION
The backend now sends IDs for sub-DTOs instead of full nested objects. This commit updates the frontend to:

- Add useAssetQuery and useProfilesQuery hooks for fetching assets and profiles by ID on demand
- Update useGroup to fetch active season from activeSeasonId
- Switch match queries to use getAllMatchesExtended (MatchDtoExtended)
- Fix MatchImpl to use seasonId, photoAssetId instead of nested objects
- Resolve player profiles via profileId + ProfileDto lookup across all screen files (newMatch, assignPoints, editMatch, cupHit, etc.)
- Update toPlayer to accept ProfileDto[] for name/avatar resolution
- Fix avatar and photo upload mutations (singleUploadUrl access)
- Update openapi.json and openapi.d.ts types to match new API schema